### PR TITLE
feat: admin 사용자 정보 수정 모달 구현

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,4 @@
 export * from './localStorage';
 export * from './paths';
+export * from './privilege';
+export * from './queryKeys';

--- a/src/constants/privilege.ts
+++ b/src/constants/privilege.ts
@@ -1,0 +1,5 @@
+export const PRIVILEGE = {
+  0: '학생',
+  1: '교수',
+  2: '관리자',
+};

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+  ADMIN_USER_EDIT: 'admin-user-edit',
+};

--- a/src/pages/Admin/api/index.ts
+++ b/src/pages/Admin/api/index.ts
@@ -1,0 +1,18 @@
+import { AxiosResponse } from 'axios';
+
+import { api } from '@/api';
+
+const API_URL = `/admin/users`;
+
+const getUser = (username: string): Promise<AxiosResponse<AdminUserResponse>> => {
+  return api.get(`${API_URL}/${username}/`);
+};
+
+const editUserPrivilege = ({
+  username,
+  privilege,
+}: EditUserRequest): Promise<AxiosResponse<AdminUserResponse>> => {
+  return api.put(`${API_URL}/${username}/`, { privilege });
+};
+
+export { getUser, editUserPrivilege };

--- a/src/pages/Admin/components/UserEditModal.tsx
+++ b/src/pages/Admin/components/UserEditModal.tsx
@@ -1,0 +1,46 @@
+import { Button, Modal, Label, Select } from '@/components';
+import { StateAndAction } from '@/types/state';
+
+import { useModalBody, useSelectUserPrivilege } from '../hooks';
+import { useEditUserPrivilegeMutation } from '../hooks/query';
+
+type UserEditModalProps<T extends React.ElementType> = Component<T> &
+  StateAndAction<boolean, 'showModal'>;
+
+export function UserEditModal({ showModal, setShowModal }: UserEditModalProps<'div'>) {
+  const { privilege, renderBody } = useModalBody();
+  const { selectedPrivilege, ...selectProps } = useSelectUserPrivilege(
+    privilege as PrivilegeNumber
+  );
+  const { mutate: editUserPrivilege } = useEditUserPrivilegeMutation();
+
+  const handleFormSubmit = () => {
+    /** FIXME: username 수정 필요 */
+    editUserPrivilege({ username: 'test230119', privilege: selectedPrivilege });
+    /** TODO: 성공, 에러 처리 추가 필요 */
+    setShowModal(false);
+  };
+
+  const handleCloseButtonClick = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <Modal open={showModal}>
+      <Modal.Header>사용자 정보 수정</Modal.Header>
+      <form onSubmit={handleFormSubmit}>
+        <Modal.Body className="w-[300px]">
+          {renderBody()}
+          <Label htmlFor="privilege">권한</Label>
+          <Select id="privilege" {...selectProps} />
+        </Modal.Body>
+        <Modal.Footer className="gap-2">
+          <Button color="success">저장하기</Button>
+          <Button color="error" type="button" onClick={handleCloseButtonClick}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/src/pages/Admin/components/index.ts
+++ b/src/pages/Admin/components/index.ts
@@ -1,0 +1,1 @@
+export * from './UserEditModal';

--- a/src/pages/Admin/hooks/index.ts
+++ b/src/pages/Admin/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useModalBody';
+export * from './useSelectUserPrivilege';

--- a/src/pages/Admin/hooks/query/index.ts
+++ b/src/pages/Admin/hooks/query/index.ts
@@ -1,0 +1,2 @@
+export * from './useUserQuery';
+export * from './useEditUserPrivilegeMutation';

--- a/src/pages/Admin/hooks/query/useEditUserPrivilegeMutation.ts
+++ b/src/pages/Admin/hooks/query/useEditUserPrivilegeMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { editUserPrivilege } from '../../api';
+
+export const useEditUserPrivilegeMutation = (
+  options?: UseMutationOptions<AxiosResponse<AdminUserResponse>, AxiosError, EditUserRequest>
+) => {
+  return useMutation(({ username, privilege }) => editUserPrivilege({ username, privilege }), {
+    ...options,
+  });
+};

--- a/src/pages/Admin/hooks/query/useUserQuery.ts
+++ b/src/pages/Admin/hooks/query/useUserQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { QUERY_KEYS } from '@/constants';
+
+import { getUser } from '../../api';
+
+export const useUserQuery = (
+  options?: UseQueryOptions<AdminUserResponse, AxiosError, AdminUserResponse, string>
+) => {
+  return useQuery(
+    QUERY_KEYS.ADMIN_USER_EDIT,
+    async () => {
+      /** FIXME: username 수정 필요 */
+      const { data } = await getUser('test230119');
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Admin/hooks/useModalBody.tsx
+++ b/src/pages/Admin/hooks/useModalBody.tsx
@@ -1,0 +1,40 @@
+import { Label, Input } from '@/components';
+
+import { useUserQuery } from './query';
+
+export const useModalBody = () => {
+  const { data: user } = useUserQuery();
+
+  const { username, name, email, privilege } = user ?? {};
+  const inputList = [
+    {
+      id: 'username',
+      label: '아이디',
+      value: username,
+    },
+    {
+      id: 'name',
+      label: '이름',
+      value: name,
+    },
+    {
+      id: 'email',
+      label: '이메일',
+      value: email,
+    },
+  ];
+
+  const renderBody = () => {
+    return inputList.map(({ id, label, value }) => (
+      <>
+        <Label htmlFor={id}>{label}</Label>
+        <Input disabled id={id} value={value} />
+      </>
+    ));
+  };
+
+  return {
+    privilege,
+    renderBody,
+  };
+};

--- a/src/pages/Admin/hooks/useSelectUserPrivilege.ts
+++ b/src/pages/Admin/hooks/useSelectUserPrivilege.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+import { PRIVILEGE } from '@/constants';
+import { getPrivilegeNumber } from '@/utils/getPrivilegeNumber';
+
+export const useSelectUserPrivilege = (initialPrivilege: PrivilegeNumber) => {
+  const [selectedPrivilege, setSelectedPrivilege] = useState(initialPrivilege);
+
+  const handleSelectChange = ({ target: { value } }: { target: HTMLSelectElement }) => {
+    const selectedValue = getPrivilegeNumber(value as PrivilegeString);
+    if (selectedValue) setSelectedPrivilege(+selectedValue as PrivilegeNumber);
+  };
+
+  const options = Object.values(PRIVILEGE).map((privilege) => ({
+    value: privilege,
+  }));
+
+  return {
+    selectedPrivilege,
+    selected: PRIVILEGE[selectedPrivilege],
+    onChange: handleSelectChange,
+    options,
+  };
+};

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -8,6 +8,10 @@ type Token = {
   refresh?: string | null;
 };
 
+type PrivilegeNumber = 0 | 1 | 2;
+
+type PrivilegeString = '학생' | '교수' | '관리자';
+
 type LoginResponse = {
   access: string;
   refresh: string;
@@ -18,3 +22,18 @@ type RegisterRequest = {
   email: string;
   password2: string;
 } & User;
+
+type EditUserRequest = {
+  privilege: PrivilegeNumber;
+  username: string;
+};
+
+type AdminUserResponse = {
+  id: number;
+  email: string;
+  username: string;
+  name: string;
+  privilege: PrivilegeNumber;
+  date_joined: string;
+  is_active: boolean;
+};

--- a/src/utils/getPrivilegeNumber.ts
+++ b/src/utils/getPrivilegeNumber.ts
@@ -1,0 +1,7 @@
+import { PRIVILEGE } from '@/constants';
+
+export const getPrivilegeNumber = (privilegeString: PrivilegeString) => {
+  return Object.keys(PRIVILEGE).find(
+    (key) => PRIVILEGE[+key as PrivilegeNumber] === privilegeString
+  );
+};


### PR DESCRIPTION
### 🚨🚨  1월 20일 커밋만 (feat 커밋만) 봐주세요 🚨🚨 
[11e302d](https://github.com/sos-sejong-opensource-software/seggle-frontend/pull/12/commits/11e302d72421ef4a11d46c5ae1c9ca83dead734d) 이 커밋부터 봐주세요..
> 브랜치 잘못 파서.. atom 브랜치 커밋이 남아있습니다....
---
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- resolve: #10 

## 구현 기능

- admin 회원 정보 요청 API 및 관련 커스텀 훅 (`useUserQuery`)
- admin 회원 정보 수정 API 및 관련 커스텀 훅 (`useEditUserPrivilegeMutation`)
- `useModalBody`
  - 모달 바디 영역을 렌더링하는 함수를 반환 
  - privilege는 form에 해당하는 부분이여서 따로 반환

- `useSelectUserPrivilege`
  - Select 컴포넌트에 사용되는 props를 반환

## 스크린샷

<img src="https://user-images.githubusercontent.com/80238096/213525713-5aea693b-05b5-4376-a421-1ecc87a28ba6.png" width="400px" />


<!--해당 PR에 대한 이미지 -->

## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

### Q. 리액트 쿼리 관련 hook에 대한 네이밍을 어떻게 하면 좋을까요?
1. `use~~Query`, `use~~~Mutation`
```ts
import { useUserQuery, useEditUserPrivilegeMutation } from '../hooks/query';
```
> 리액트 쿼리 훅 이름이 Query 또는 Mutation으로 끝난다.
- 장점: 이름만 보고 일반 커스텀 훅과 쿼리 훅을 구분할 수 있다.
- 단점: 이름이 지나치게 길어질 수 있다 (useEditUserPrivilegeMutation)

2. `use~~`
```ts
import { useGetUser, useEditUserPrivilege } from '../hooks/query';
```
- 장점: 적당한 길이의 이름으로 정할 수 있다. query 폴더로 분류하면 경로를 보고 일반 커스텀 훅과 구별할 수 있다.
- 단점: 경로를 보지 않고 이름만 보는 경우에는 일반 커스텀 훅과 헷갈릴 수 있다.

---

- 새벽에 짜서 정신이 하나도 x .. 마음껏 지적부탁드립니다.. 🫠