### PR TITLE
feat: 페이지 레이아웃 반응형 & Heading 반응형 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,20 +11,22 @@ export default function App() {
   return (
     <>
       <MainHeader />
-      <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
-          <Route path={PATH.HOME} element={<Home />} />
-          <Route path={PATH.LOGIN} element={<Login />} />
-          <Route path={PATH.REGISTER} element={<Register />} />
-          <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
-          <Route path={PATH.CLASS_LIST} element={<div>ClassList</div>} />
-          <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
-          <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />
-          <Route path={PATH.FAQ} element={<Faq />} />
+      <div className="container">
+        <Suspense fallback={<div>Loading...</div>}>
+          <Routes>
+            <Route path={PATH.HOME} element={<Home />} />
+            <Route path={PATH.LOGIN} element={<Login />} />
+            <Route path={PATH.REGISTER} element={<Register />} />
+            <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
+            <Route path={PATH.CLASS_LIST} element={<div>ClassList</div>} />
+            <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
+            <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />
+            <Route path={PATH.FAQ} element={<Faq />} />
 
-          <Route path="*" element={<div>Not Found</div>} />
-        </Routes>
-      </Suspense>
+            <Route path="*" element={<div>Not Found</div>} />
+          </Routes>
+        </Suspense>
+      </div>
     </>
   );
 }

--- a/src/components/atom/Heading.tsx
+++ b/src/components/atom/Heading.tsx
@@ -49,7 +49,7 @@ const defaultHeadingStyle = 'font-bold';
 
 function Heading1({ className, children, ...props }: HeadingProps<'h1'>) {
   return (
-    <h1 className={tw('text-4xl', defaultHeadingStyle, className)} {...props}>
+    <h1 className={tw('text-3xl sm:text-4xl', defaultHeadingStyle, className)} {...props}>
       {children}
     </h1>
   );
@@ -57,7 +57,7 @@ function Heading1({ className, children, ...props }: HeadingProps<'h1'>) {
 
 function Heading2({ className, children, ...props }: HeadingProps<'h2'>) {
   return (
-    <h2 className={tw('text-3xl', defaultHeadingStyle, className)} {...props}>
+    <h2 className={tw('text-2xl sm:text-3xl', defaultHeadingStyle, className)} {...props}>
       {children}
     </h2>
   );
@@ -65,7 +65,7 @@ function Heading2({ className, children, ...props }: HeadingProps<'h2'>) {
 
 function Heading3({ className, children, ...props }: HeadingProps<'h3'>) {
   return (
-    <h3 className={tw('text-2xl', defaultHeadingStyle, className)} {...props}>
+    <h3 className={tw('text-xl sm:text-2xl', defaultHeadingStyle, className)} {...props}>
       {children}
     </h3>
   );
@@ -73,7 +73,7 @@ function Heading3({ className, children, ...props }: HeadingProps<'h3'>) {
 
 function Heading4({ className, children, ...props }: HeadingProps<'h4'>) {
   return (
-    <h4 className={tw('text-xl', defaultHeadingStyle, className)} {...props}>
+    <h4 className={tw('text-lg sm:text-xl', defaultHeadingStyle, className)} {...props}>
       {children}
     </h4>
   );
@@ -81,7 +81,7 @@ function Heading4({ className, children, ...props }: HeadingProps<'h4'>) {
 
 function Heading5({ className, children, ...props }: HeadingProps<'h5'>) {
   return (
-    <h5 className={tw('text-lg', defaultHeadingStyle, className)} {...props}>
+    <h5 className={tw('text-base sm:text-lg', defaultHeadingStyle, className)} {...props}>
       {children}
     </h5>
   );
@@ -89,7 +89,7 @@ function Heading5({ className, children, ...props }: HeadingProps<'h5'>) {
 
 function Heading6({ className, children, ...props }: HeadingProps<'h6'>) {
   return (
-    <h6 className={tw('text-base', defaultHeadingStyle, className)} {...props}>
+    <h6 className={tw('text-md sm:text-base', defaultHeadingStyle, className)} {...props}>
       {children}
     </h6>
   );

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -16,6 +16,17 @@ module.exports = {
     fontFamily: {
       Pretendard: 'Pretendard',
     },
+    container: {
+      center: true,
+      screens: {
+        xs: '280px',
+        sm: '440px',
+        md: '568px',
+        lg: '824px',
+        xl: '1080px',
+        '2xl': '1336px',
+      },
+    },
     extend: {
       colors: {
         primary: colors.indigo,


### PR DESCRIPTION
## 구현 기능
- 페이지 레이아웃 반응형
  - 기준: [tailwind container](https://tailwindcss.com/docs/container)의 기본값에서 -200px

## 변경 로직
- Heading 반응형 수정
  - 스크린 넓이에 따라 글자 크기 수정

## 스크린샷

<!--해당 PR에 대한 이미지 -->
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/80238096/215266933-5e33d45d-d475-460d-9982-60db53e57fe4.png">



## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- [tailwind container](https://tailwindcss.com/docs/container)
