### PR TITLE
feat:  수업 리스트 조회 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq } from '@/pages';
+import { Login, Register, Faq, ClassList } from '@/pages';
 import { Announcement } from './pages/Announcement/Announcement';
 import { MainHeader } from '@/components';
 import { PATH } from '@/constants';
@@ -19,7 +19,7 @@ export default function App() {
             <Route path={PATH.LOGIN} element={<Login />} />
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
-            <Route path={PATH.CLASS_LIST} element={<div>ClassList</div>} />
+            <Route path={PATH.CLASS_LIST} element={<ClassList />} />
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
             <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />
             <Route path={PATH.FAQ} element={<Faq />} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -31,6 +31,7 @@ export const PATH: { [key: string]: string } = {
   COMPETITION_FORM: `${BASE_PATH.COMPETITION}/form`,
 
   CLASS_LIST: `${BASE_PATH.CLASS}`,
+  CLASS_LIST_EDIT: `${BASE_PATH.CLASS}/edit-class`,
   CLASS_DETAIL: `${BASE_PATH.CLASS}/:id`,
   CLASS_FORM: `${BASE_PATH.CLASS}/form`,
 };
@@ -38,4 +39,6 @@ export const PATH: { [key: string]: string } = {
 export const PAGE: { [key: string]: string } = {
   LOGIN: '로그인',
   REGISTER: '회원가입',
+
+  CLASS_LIST: '수업 및 시험',
 };

--- a/src/pages/Class/ClassList.tsx
+++ b/src/pages/Class/ClassList.tsx
@@ -1,0 +1,19 @@
+import { Button, Heading, LinkButton, Table } from '@/components';
+import { PATH, PAGE } from '@/constants';
+
+import { useClassListTable } from './hooks';
+
+export function ClassList() {
+  const { column, data, handleRowClick } = useClassListTable();
+
+  return (
+    <>
+      <header className="flex items-center">
+        <Heading>{PAGE.CLASS_LIST}</Heading>
+        <LinkButton to={PATH.CLASS_LIST_EDIT}>편집</LinkButton>
+        <Button>수업 생성</Button>
+      </header>
+      <Table column={column} data={data} onRowClick={handleRowClick} />
+    </>
+  );
+}

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -1,0 +1,11 @@
+import { AxiosResponse } from 'axios';
+
+import { api } from '@/api';
+
+const API_URL = `/class/`;
+
+const getClassList = (): Promise<AxiosResponse<ClassListResponse>> => {
+  return api.get(`/users${API_URL}`);
+};
+
+export { getClassList };

--- a/src/pages/Class/hooks/index.ts
+++ b/src/pages/Class/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './query';
+export * from './useClassListTable';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -1,0 +1,1 @@
+export * from './useClassListQuery';

--- a/src/pages/Class/hooks/query/useClassListQuery.ts
+++ b/src/pages/Class/hooks/query/useClassListQuery.ts
@@ -1,0 +1,22 @@
+import { UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getClassList } from '../../api';
+
+export const useClassListQuery = (
+  options?: UseQueryOptions<ClassListResponse, AxiosError, ClassListResponse, string>
+) => {
+  return useSuspenseQuery(
+    QUERY_KEYS.FAQ,
+    async () => {
+      const { data } = await getClassList();
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/useClassListTable.ts
+++ b/src/pages/Class/hooks/useClassListTable.ts
@@ -1,0 +1,29 @@
+import { useNavigate } from 'react-router-dom';
+
+import { PATH } from '@/constants/paths';
+
+import { useClassListQuery } from './query';
+
+export const useClassListTable = () => {
+  const navigate = useNavigate();
+
+  const column = [
+    { Header: '연도', accessor: 'year' },
+    { Header: '학기', accessor: 'semester' },
+    { Header: '제목', accessor: 'name' },
+  ];
+
+  const { data: classList } = useClassListQuery();
+  const data = classList
+    .sort(({ year: prev }, { year: next }) => next - prev)
+    .filter(({ is_show }) => is_show);
+
+  const handleRowClick = (
+    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    id: number | string
+  ) => {
+    navigate(`${PATH.CLASS}/${id}`);
+  };
+
+  return { column, data, handleRowClick };
+};

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -1,0 +1,1 @@
+export * from './ClassList';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export * from './User';
 export * from './Faq';
+export * from './Class';

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -1,0 +1,8 @@
+type ClassListResponse = {
+  id: number;
+  name: string;
+  year: number;
+  semester: number;
+  privilege: PrivilegeNumber;
+  is_show: boolean;
+}[];


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to: #30 

## 구현 기능
- 연도별 정렬, is_show인 수업만 렌더링
- Row 클릭 시, 수업 페이지로 이동

## 스크린샷

<!--해당 PR에 대한 이미지 -->

![image](https://user-images.githubusercontent.com/80238096/215972532-d3540687-fb74-4814-b7da-fef199bd127f.png)


## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- 스크린샷은 mock 데이터로 구현하였습니다.
- 수업 리스트 편집 페이지도 구현했는데 커밋양이 많아서 수업 리스트 조회 페이지 먼저 PR 올립니다~
