### PR TITLE
feat: 수업 목록 편집 페이지 - 수업 공개 여부

### DIFF
--- a/src/components/atom/Input.tsx
+++ b/src/components/atom/Input.tsx
@@ -6,7 +6,7 @@ export function Input({ className, onChange, ...props }: InputProps<'input'>) {
   return (
     <input
       className={tw(
-        'appearance-none rounded-none relative block px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm',
+        'rounded-none relative block px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm',
         className
       )}
       onChange={onChange}

--- a/src/components/atom/Select.tsx
+++ b/src/components/atom/Select.tsx
@@ -1,7 +1,7 @@
 import { tw } from '@/utils/tailwindMerge';
 
 type SelectProps<T extends React.ElementType> = Component<T> & {
-  selected: string;
+  selected?: string;
   options: Array<{ value: string }>;
 };
 

--- a/src/pages/Class/ClassListEdit.tsx
+++ b/src/pages/Class/ClassListEdit.tsx
@@ -1,0 +1,26 @@
+import { Button, Heading, Table } from '@/components';
+import { PAGE } from '@/constants';
+
+import { useClassListEditTable, useEditClassListMutation } from './hooks';
+
+export function ClassListEdit() {
+  const { column, data, handleRowClick } = useClassListEditTable();
+
+  const { mutate: editClassList } = useEditClassListMutation();
+
+  const handleShowButtonClick = () => {
+    const classIdList = data.map(({ id }) => ({ class_id: id }));
+
+    editClassList(classIdList);
+  };
+
+  return (
+    <>
+      <header className="flex items-center">
+        <Heading>{PAGE.CLASS_LIST}</Heading>
+        <Button onClick={handleShowButtonClick}>저장</Button>
+      </header>
+      <Table column={column} data={data} onRowClick={handleRowClick} />
+    </>
+  );
+}

--- a/src/pages/Class/ClassListEdit.tsx
+++ b/src/pages/Class/ClassListEdit.tsx
@@ -4,7 +4,7 @@ import { PAGE } from '@/constants';
 import { useClassListEditTable, useEditClassListMutation } from './hooks';
 
 export function ClassListEdit() {
-  const { column, data, handleRowClick } = useClassListEditTable();
+  const { column, data } = useClassListEditTable();
 
   const { mutate: editClassList } = useEditClassListMutation();
 
@@ -20,7 +20,7 @@ export function ClassListEdit() {
         <Heading>{PAGE.CLASS_LIST}</Heading>
         <Button onClick={handleShowButtonClick}>저장</Button>
       </header>
-      <Table column={column} data={data} onRowClick={handleRowClick} />
+      <Table column={column} data={data} />
     </>
   );
 }

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -2,10 +2,14 @@ import { AxiosResponse } from 'axios';
 
 import { api } from '@/api';
 
-const API_URL = `/class/`;
+const API_URL = `/class`;
 
 const getClassList = (): Promise<AxiosResponse<ClassListResponse>> => {
-  return api.get(`/users${API_URL}`);
+  return api.get(`/users${API_URL}/`);
 };
 
-export { getClassList };
+const editClassList = (payload: ClassListIdRequest) => {
+  return api.patch(`/users${API_URL}/`, payload);
+};
+
+export { getClassList, editClassList };

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -1,1 +1,2 @@
 export * from './useClassListQuery';
+export * from './useEditClassListMutation';

--- a/src/pages/Class/hooks/query/useEditClassListMutation.ts
+++ b/src/pages/Class/hooks/query/useEditClassListMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { editClassList } from '../../api';
+
+export const useEditClassListMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, ClassListIdRequest>
+) => {
+  return useMutation((payload) => editClassList(payload), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/useClassListEditTable.tsx
+++ b/src/pages/Class/hooks/useClassListEditTable.tsx
@@ -1,0 +1,47 @@
+import { Button, Input } from '@/components';
+
+import { useClassListQuery } from './query';
+
+const mockData = [
+  {
+    id: 1,
+    name: '기계학습',
+    year: 2021,
+    semester: 1,
+    privilege: 1,
+    is_show: true,
+  },
+];
+
+export const useClassListEditTable = () => {
+  const column = [
+    { Header: '공개', accessor: 'visible' },
+    { Header: '연도', accessor: 'year' },
+    { Header: '학기', accessor: 'semester' },
+    { Header: '제목', accessor: 'name' },
+    { Header: '편집', accessor: 'edit' },
+    { Header: '삭제', accessor: 'delete' },
+  ];
+
+  const { data: classList } = useClassListQuery();
+  /** FIXME: mockData → classList로 변경 */
+  const data = mockData
+    .sort(({ year: prev }, { year: next }) => next - prev)
+    .map((_class) => ({
+      ..._class,
+      visible: <Input type="checkbox" defaultChecked={_class.is_show} className="inline-block" />,
+      edit: <Button>편집</Button>,
+      delete: <Button>삭제</Button>,
+    }));
+
+  const handleRowClick = (
+    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    id: number | string
+  ) => null;
+
+  return {
+    column,
+    data,
+    handleRowClick,
+  };
+};

--- a/src/pages/Class/hooks/useClassListEditTable.tsx
+++ b/src/pages/Class/hooks/useClassListEditTable.tsx
@@ -34,14 +34,8 @@ export const useClassListEditTable = () => {
       delete: <Button>삭제</Button>,
     }));
 
-  const handleRowClick = (
-    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
-    id: number | string
-  ) => null;
-
   return {
     column,
     data,
-    handleRowClick,
   };
 };

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -1,1 +1,2 @@
 export * from './ClassList';
+export * from './ClassListEdit';

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -6,3 +6,7 @@ type ClassListResponse = {
   privilege: PrivilegeNumber;
   is_show: boolean;
 }[];
+
+type ClassListIdRequest = {
+  class_id: number;
+}[];


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to: #30 

## 구현 기능

- 수업 목록 편집 페이지 UI
- 수업 공개 수정 후 저장 기능

## 변경 로직

- Select 컴포넌트 props 수정
  -  selected props를 optional하게 변경
- Input 컴포넌트 수정
  - `type="checkbox"`일 때 요소가 안보여서 스타일 속성 삭제

## 스크린샷
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/216034901-61b66b6b-5878-45ef-9d5b-570846971df6.png">


<!--해당 PR에 대한 이미지 -->

## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- `handleRowClick` props를 optional로 변경 가능한가요? 
   - 수업 리스트 편집 페이지에서는 Row에 클릭 이벤트를 사용하고 있지 않습니다

- 스크린샷은 mock 데이터로 구현하였습니다.
- 수업 편집 / 삭제까지 올리면 커밋 양이 많아져서 나눠서 올리도록 하겠습니다~