### PR TITLE
[feat] 토글 스위치 atom & 테이블 onRowClick 선택으로 수정

### DIFF
--- a/src/components/atom/Switch.tsx
+++ b/src/components/atom/Switch.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type SwitchProps<T extends React.ElementType> = Component<T> & {
+  enabled: boolean;
+};
+
+export function Switch({ enabled, onClick, className }: SwitchProps<'button'>) {
+  return (
+    <div className={className}>
+      <label className="inline-flex relative items-center cursor-pointer">
+        <input type="checkbox" className="sr-only peer" checked={enabled} readOnly />
+        <button
+          onClick={onClick}
+          className="w-11 h-6 bg-gray-200 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-300"
+        ></button>
+      </label>
+    </div>
+  );
+}

--- a/src/components/molecule/Table.tsx
+++ b/src/components/molecule/Table.tsx
@@ -5,7 +5,7 @@ import './Table.css';
 type TableProps<T extends React.ElementType> = Component<T> & {
   column: Array<{ Header: string; accessor: string }>;
   data: Array<{ id: string | number } & object>;
-  onRowClick: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, id: number | string) => void;
+  onRowClick?: (e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, id: number | string) => void;
 };
 
 type TheadProps = {
@@ -44,7 +44,7 @@ function Tbody({ column, data, onRowClick }: TableProps<'table'>) {
         <tr
           key={key}
           className="border-b border-primary-100 table-row"
-          onClick={(e) => onRowClick(e, value['id'])}
+          onClick={(e) => onRowClick && onRowClick(e, value['id'])}
         >
           {column.map(({ accessor }) => {
             return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import Form from '@/components/Form';
 import { Modal } from '@/components';
 import { Table } from '@/components';
 import Pagination from '@/components/Pagination';
+import { Switch } from '@/components/atom/Switch';
 
 export default function Home() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -62,6 +63,10 @@ export default function Home() {
 
       <h1 className="text-3xl text-blue-400 px-3 py-3">Table</h1>
       <Table column={column} data={data} onRowClick={handleRowClick} />
+
+      <h1 className="text-3xl text-blue-400 px-3 py-3">Switch</h1>
+      <Switch enabled={false} onClick={() => console.log('click')} />
+      <Switch enabled={true} onClick={() => console.log('click')} />
 
       <h1 className="text-3xl text-blue-400 px-3 py-3">Pagination</h1>
       <Pagination


### PR DESCRIPTION
## 구현 기능
### 토글 스위치
* 테이블 등에서 사용할 토글 스위치 버튼

### 사용
```typescript
<Switch enabled={enabled} onClick={onClick} />
```

| props | value | 설명 |
| --- | --- | --- |
| enabled | boolean | 토글 스위치의 value값(true/false) |
| onClick | function | 토글 스위치 클릭시 실행할 함수 |

## 스크린샷
<img width="153" alt="image" src="https://user-images.githubusercontent.com/63294532/216213426-dffe42e7-2733-4da7-b7a3-3aef3ace5f41.png">

## 변경로직
* Table 컴포넌트 `onRowClick` props를 선택사항으로 변경
  * row마다 click이 필요하지 않는 페이지가 있기 때문에 변경
