### PR TITLE
feat: 수업 목록 편집 페이지 - 수업 편집, 삭제

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,5 +1,6 @@
 export const QUERY_KEYS = {
   ADMIN_USER_EDIT: 'admin-user-edit',
   FAQ: 'faq',
-  ANNOUNCEMENT: 'announcement'
+  ANNOUNCEMENT: 'announcement',
+  CLASS: 'class',
 };

--- a/src/pages/Class/ClassListEdit.tsx
+++ b/src/pages/Class/ClassListEdit.tsx
@@ -2,9 +2,10 @@ import { Button, Heading, Table } from '@/components';
 import { PAGE } from '@/constants';
 
 import { useClassListEditTable, useEditClassListMutation } from './hooks';
+import { ClassEditModal } from './components';
 
 export function ClassListEdit() {
-  const { column, data } = useClassListEditTable();
+  const { column, data, modalProps } = useClassListEditTable();
 
   const { mutate: editClassList } = useEditClassListMutation();
 
@@ -21,6 +22,7 @@ export function ClassListEdit() {
         <Button onClick={handleShowButtonClick}>저장</Button>
       </header>
       <Table column={column} data={data} />
+      {modalProps.showModal && <ClassEditModal {...modalProps} />}
     </>
   );
 }

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -12,4 +12,16 @@ const editClassList = (payload: ClassListIdRequest) => {
   return api.patch(`/users${API_URL}/`, payload);
 };
 
-export { getClassList, editClassList };
+const getClass = (classId: string): Promise<AxiosResponse<ClassResponse>> => {
+  return api.get(`${API_URL}/${classId}/`);
+};
+
+const editClass = ({ classId, payload }: { classId: string; payload: ClassRequest }) => {
+  return api.patch(`${API_URL}/${classId}`, payload);
+};
+
+const deleteClass = (classId: string) => {
+  return api.delete(`${API_URL}/${classId}`);
+};
+
+export { getClassList, editClassList, getClass, editClass, deleteClass };

--- a/src/pages/Class/components/ClassEditModal.tsx
+++ b/src/pages/Class/components/ClassEditModal.tsx
@@ -1,0 +1,46 @@
+import { Button, Modal } from '@/components';
+import { StateAndAction } from '@/types/state';
+
+import { useModalBody } from '../hooks';
+import { useEditClassMutation } from '../hooks/query';
+
+type ClassListEditModalProps<T extends React.ElementType> = Component<T> & {
+  classId: string;
+} & StateAndAction<boolean, 'showModal'>;
+
+export function ClassEditModal({
+  classId,
+  showModal,
+  setShowModal,
+}: ClassListEditModalProps<'div'>) {
+  const { renderBody } = useModalBody(classId);
+  const { mutate: editClass } = useEditClassMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => {
+    e.preventDefault();
+
+    const [year, semester, name] = Object.values(e.target).map(({ value }) => value);
+    editClass({ classId, payload: { year, semester, name } });
+
+    setShowModal(false);
+  };
+
+  const handleCloseButtonClick = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <Modal open={showModal}>
+      <Modal.Header>수업 편집</Modal.Header>
+      <form onSubmit={handleFormSubmit}>
+        <Modal.Body className="w-[300px]">{renderBody()}</Modal.Body>
+        <Modal.Footer className="gap-2">
+          <Button color="success">저장하기</Button>
+          <Button color="error" type="button" onClick={handleCloseButtonClick}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/src/pages/Class/components/index.ts
+++ b/src/pages/Class/components/index.ts
@@ -1,0 +1,1 @@
+export * from './ClassEditModal';

--- a/src/pages/Class/hooks/index.ts
+++ b/src/pages/Class/hooks/index.ts
@@ -1,2 +1,5 @@
 export * from './query';
+
 export * from './useClassListTable';
+export * from './useClassListEditTable';
+export * from './useModalBody';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -1,2 +1,6 @@
 export * from './useClassListQuery';
 export * from './useEditClassListMutation';
+
+export * from './useClassQuery';
+export * from './useEditClassMutation';
+export * from './useDeleteClassMutation';

--- a/src/pages/Class/hooks/query/useClassQuery.ts
+++ b/src/pages/Class/hooks/query/useClassQuery.ts
@@ -1,0 +1,23 @@
+import { QueryKey, UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { QUERY_KEYS } from '@/constants';
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+
+import { getClass } from '../../api';
+
+export const useClassQuery = (
+  classId: QueryKey,
+  options?: UseQueryOptions<ClassResponse, AxiosError, ClassResponse, QueryKey[]>
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS, classId],
+    async ({ queryKey: [, classId] }) => {
+      const { data } = await getClass(String(classId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/query/useDeleteClassMutation.ts
+++ b/src/pages/Class/hooks/query/useDeleteClassMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { deleteClass } from '../../api';
+
+export const useDeleteClassMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, string>
+) => {
+  return useMutation((classId) => deleteClass(classId), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useEditClassMutation.ts
+++ b/src/pages/Class/hooks/query/useEditClassMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { editClass } from '../../api';
+
+type useEditClassProps = { classId: string; payload: ClassRequest };
+
+export const useEditClassMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useEditClassProps>
+) => {
+  return useMutation(({ classId, payload }) => editClass({ classId, payload }), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/useClassListEditTable.tsx
+++ b/src/pages/Class/hooks/useClassListEditTable.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
+
 import { Button, Input } from '@/components';
 
-import { useClassListQuery } from './query';
+import { useClassListQuery, useDeleteClassMutation } from './query';
 
 const mockData = [
   {
@@ -23,19 +25,38 @@ export const useClassListEditTable = () => {
     { Header: '삭제', accessor: 'delete' },
   ];
 
+  const [showModal, setShowModal] = useState(false);
+  const [editingClassId, setEditingClassId] = useState('');
+
+  const { mutate: deleteClass } = useDeleteClassMutation();
+
+  const handleEditButtonClick = (id: number) => {
+    setEditingClassId(`${id}`);
+    setShowModal(true);
+  };
+
+  const handleDeleteButtonClick = ({ name, id }: { name: string; id: number }) => {
+    const isConfirmed = confirm(`${name}을 삭제하시겠습니까?`);
+    if (isConfirmed) deleteClass(`${id}`);
+  };
+
   const { data: classList } = useClassListQuery();
   /** FIXME: mockData → classList로 변경 */
   const data = mockData
     .sort(({ year: prev }, { year: next }) => next - prev)
-    .map((_class) => ({
-      ..._class,
-      visible: <Input type="checkbox" defaultChecked={_class.is_show} className="inline-block" />,
-      edit: <Button>편집</Button>,
-      delete: <Button>삭제</Button>,
-    }));
+    .map((_class) => {
+      const { id, name, is_show } = _class;
+      return {
+        ..._class,
+        visible: <Input type="checkbox" defaultChecked={is_show} className="inline-block" />,
+        edit: <Button onClick={() => handleEditButtonClick(id)}>편집</Button>,
+        delete: <Button onClick={() => handleDeleteButtonClick({ id, name })}>삭제</Button>,
+      };
+    });
 
   return {
     column,
     data,
+    modalProps: { classId: editingClassId, showModal, setShowModal },
   };
 };

--- a/src/pages/Class/hooks/useClassListTable.ts
+++ b/src/pages/Class/hooks/useClassListTable.ts
@@ -13,8 +13,10 @@ export const useClassListTable = () => {
     { Header: '제목', accessor: 'name' },
   ];
 
-  const { data: classList } = useClassListQuery();
-  const data = classList
+  const {
+    data: { results },
+  } = useClassListQuery();
+  const data = results
     .sort(({ year: prev }, { year: next }) => next - prev)
     .filter(({ is_show }) => is_show);
 

--- a/src/pages/Class/hooks/useModalBody.tsx
+++ b/src/pages/Class/hooks/useModalBody.tsx
@@ -1,0 +1,45 @@
+import { Label, Select, Input } from '@/components';
+
+import { useClassQuery } from './query';
+
+export const useModalBody = (id: string) => {
+  const { data: _class } = useClassQuery(id);
+
+  const { year, semester, name } = _class;
+  const contents = [
+    {
+      id: 'year',
+      label: '연도',
+      element: <Select id="year" selected={`${year}`} disabled options={[{ value: `${year}` }]} />,
+    },
+    {
+      id: 'semeter',
+      label: '학기',
+      element: (
+        <Select
+          id="semester"
+          defaultValue={`${semester}`}
+          options={[{ value: '1' }, { value: '2' }]}
+        />
+      ),
+    },
+    {
+      id: 'name',
+      label: '수업명(학기명)',
+      element: <Input id="name" defaultValue={name} />,
+    },
+  ];
+
+  const renderBody = () => {
+    return contents.map(({ id, label, element }) => (
+      <>
+        <Label htmlFor={id}>{label}</Label>
+        {element}
+      </>
+    ));
+  };
+
+  return {
+    renderBody,
+  };
+};

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -1,4 +1,11 @@
 type ClassListResponse = {
+  count: number;
+  next: number | null;
+  previous: number | nulle;
+  results: ClassList;
+};
+
+type ClassList = {
   id: number;
   name: string;
   year: number;
@@ -10,3 +17,16 @@ type ClassListResponse = {
 type ClassListIdRequest = {
   class_id: number;
 }[];
+
+type ClassRequest = {
+  name: string;
+  year: number;
+  semester: number;
+};
+
+type ClassResponse = {
+  name: string;
+  year: number;
+  semester: number;
+  created_user: string;
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to: #30 

## 구현 기능

- 수업 편집 버튼 기능
  - 수업 조회 후 편집

- 수업 삭제 버튼 기능

## 스크린샷

<!--해당 PR에 대한 이미지 -->

### 수업 편집
<img width="700" src="https://user-images.githubusercontent.com/80238096/216274912-23bc202a-56e9-4002-8164-fd6ca144fb21.png" />

### 수업 삭제
![스크린샷 2023-02-01 오후 3 49 05](https://user-images.githubusercontent.com/80238096/216274953-b2f80aa4-26e0-4e73-82a1-0b073ec0fc03.png)


## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- 스크린샷은 mock 데이터로 구현하였습니다
- 모달 렌더링하는 부분을 통일할 필요가 있어 보입니다.. 추후 리팩토링 필수..