### PR TITLE
feat: 수업 목록 페이지 - 수업 생성 

### DIFF
--- a/src/pages/Class/ClassList.tsx
+++ b/src/pages/Class/ClassList.tsx
@@ -1,9 +1,13 @@
+import { useState } from 'react';
+
 import { Button, Heading, LinkButton, Table } from '@/components';
 import { PATH, PAGE } from '@/constants';
 
 import { useClassListTable } from './hooks';
+import { ClassFormModal } from './components';
 
 export function ClassList() {
+  const [showModal, setShowModal] = useState(false);
   const { column, data, handleRowClick } = useClassListTable();
 
   return (
@@ -11,9 +15,10 @@ export function ClassList() {
       <header className="flex items-center">
         <Heading>{PAGE.CLASS_LIST}</Heading>
         <LinkButton to={PATH.CLASS_LIST_EDIT}>편집</LinkButton>
-        <Button>수업 생성</Button>
+        <Button onClick={() => setShowModal(true)}>수업 생성</Button>
       </header>
       <Table column={column} data={data} onRowClick={handleRowClick} />
+      {showModal && <ClassFormModal showModal={showModal} setShowModal={setShowModal} />}
     </>
   );
 }

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -16,6 +16,10 @@ const getClass = (classId: string): Promise<AxiosResponse<ClassResponse>> => {
   return api.get(`${API_URL}/${classId}/`);
 };
 
+const createClass = (payload: ClassRequest) => {
+  return api.post(`${API_URL}/`, payload);
+};
+
 const editClass = ({ classId, payload }: { classId: string; payload: ClassRequest }) => {
   return api.patch(`${API_URL}/${classId}`, payload);
 };
@@ -24,4 +28,4 @@ const deleteClass = (classId: string) => {
   return api.delete(`${API_URL}/${classId}`);
 };
 
-export { getClassList, editClassList, getClass, editClass, deleteClass };
+export { getClassList, editClassList, getClass, createClass, editClass, deleteClass };

--- a/src/pages/Class/components/ClassEditModal.tsx
+++ b/src/pages/Class/components/ClassEditModal.tsx
@@ -2,7 +2,7 @@ import { Button, Modal } from '@/components';
 import { StateAndAction } from '@/types/state';
 
 import { useModalBody } from '../hooks';
-import { useEditClassMutation } from '../hooks/query';
+import { useEditClassMutation, useClassQuery } from '../hooks/query';
 
 type ClassListEditModalProps<T extends React.ElementType> = Component<T> & {
   classId: string;
@@ -13,7 +13,8 @@ export function ClassEditModal({
   showModal,
   setShowModal,
 }: ClassListEditModalProps<'div'>) {
-  const { renderBody } = useModalBody(classId);
+  const { data } = useClassQuery(classId);
+  const { renderBody } = useModalBody(data);
   const { mutate: editClass } = useEditClassMutation();
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => {

--- a/src/pages/Class/components/ClassFormModal.tsx
+++ b/src/pages/Class/components/ClassFormModal.tsx
@@ -1,0 +1,40 @@
+import { Button, Modal } from '@/components';
+import { StateAndAction } from '@/types/state';
+
+import { useModalBody, useCreateClassListMutation } from '../hooks';
+
+type ClassFormModalProps<T extends React.ElementType> = Component<T> &
+  StateAndAction<boolean, 'showModal'>;
+
+export function ClassFormModal({ showModal, setShowModal }: ClassFormModalProps<'div'>) {
+  const { renderBody } = useModalBody();
+  const { mutate: createClass } = useCreateClassListMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => {
+    e.preventDefault();
+
+    const [year, semester, name] = Object.values(e.target).map(({ value }) => value);
+    createClass({ year, semester, name });
+
+    setShowModal(false);
+  };
+
+  const handleCloseButtonClick = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <Modal open={showModal}>
+      <Modal.Header>수업 생성</Modal.Header>
+      <form onSubmit={handleFormSubmit}>
+        <Modal.Body className="w-[300px]">{renderBody()}</Modal.Body>
+        <Modal.Footer className="gap-2">
+          <Button color="success">저장하기</Button>
+          <Button color="error" type="button" onClick={handleCloseButtonClick}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/src/pages/Class/components/index.ts
+++ b/src/pages/Class/components/index.ts
@@ -1,1 +1,2 @@
 export * from './ClassEditModal';
+export * from './ClassFormModal';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -2,5 +2,6 @@ export * from './useClassListQuery';
 export * from './useEditClassListMutation';
 
 export * from './useClassQuery';
+export * from './useCreateClassMutation';
 export * from './useEditClassMutation';
 export * from './useDeleteClassMutation';

--- a/src/pages/Class/hooks/query/useCreateClassMutation.ts
+++ b/src/pages/Class/hooks/query/useCreateClassMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createClass } from '../../api';
+
+export const useCreateClassListMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, ClassRequest>
+) => {
+  return useMutation((payload) => createClass(payload), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/useModalBody.tsx
+++ b/src/pages/Class/hooks/useModalBody.tsx
@@ -1,11 +1,7 @@
 import { Label, Select, Input } from '@/components';
 
-import { useClassQuery } from './query';
-
-export const useModalBody = (id: string) => {
-  const { data: _class } = useClassQuery(id);
-
-  const { year, semester, name } = _class;
+export const useModalBody = (data?: ClassResponse) => {
+  const { year, semester, name } = data ?? { year: new Date().getFullYear() };
   const contents = [
     {
       id: 'year',
@@ -17,8 +13,9 @@ export const useModalBody = (id: string) => {
       label: '학기',
       element: (
         <Select
+          required
           id="semester"
-          defaultValue={`${semester}`}
+          defaultValue={semester}
           options={[{ value: '1' }, { value: '2' }]}
         />
       ),
@@ -26,7 +23,7 @@ export const useModalBody = (id: string) => {
     {
       id: 'name',
       label: '수업명(학기명)',
-      element: <Input id="name" defaultValue={name} />,
+      element: <Input required id="name" defaultValue={name} />,
     },
   ];
 


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Resolve: #30 

## 구현 기능

- 수업 생성
  - 연도: 현재 연도로 자동 설정됩니다. (disabled)
  - 학기: 1, 2만 존재합니다

## 변경 로직

- useModalBody
  - 생성 모달, 편집 모달에서 둘 다 사용될 수 있도록 수정
  - 입력 required 추가

## 스크린샷

<!--해당 PR에 대한 이미지 -->

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/216773440-270dd527-cb11-4256-9265-3bb346bf463b.png">


## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- ~~현재 500에러로 수업이 제대로 생성되지 않습니다. 현재 백엔드쪽에 문의 남겼고 해결되면 기능 확인 후 머지하도록 하겠습니다~~
기능 확인 완료했습니다!