### PR TITLE
feat: 수업 페이지 - 수강생 및 TA 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,9 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq, Admin, ClassList } from '@/pages';
+import { Login, Register, Faq, Admin, ClassList, ClassStudentManagement } from '@/pages';
 import { MainHeader } from '@/components';
-import { PATH } from '@/constants';
+import { PATH, SUB_PATH } from '@/constants';
 
 export default function App() {
   return (
@@ -19,6 +19,9 @@ export default function App() {
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
             <Route path={PATH.CLASS_LIST} element={<ClassList />} />
+            <Route path={PATH.CLASS_DETAIL} element={<div></div>}>
+              <Route path={SUB_PATH.STUDENT_MANAGEMENT} element={<ClassStudentManagement />} />
+            </Route>
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
             <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />
             <Route path={PATH.FAQ} element={<Faq />} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -13,7 +13,7 @@ export const BASE_PATH: { [key: string]: string } = {
   ADMIN: '/admin',
 };
 
-const SUB_PATH = {
+export const SUB_PATH = {
   DATA: 'data',
   DESCRIPTION: 'description',
   LEADERBOARD: 'leaderboard',
@@ -24,6 +24,7 @@ const SUB_PATH = {
   ANNOUNCEMENTS: 'announcements',
   FAQS: 'faqs',
   USER_MANAGEMENT: 'user-management',
+  STUDENT_MANAGEMENT: 'student-management',
 };
 
 export const PATH: { [key: string]: string } = {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -3,4 +3,6 @@ export const QUERY_KEYS = {
   FAQ: 'faq',
   ANNOUNCEMENT: 'announcement',
   CLASS: 'class',
+  CLASS_STUDENT: 'class-student',
+  CLASS_TA: 'class-ta',
 };

--- a/src/pages/Class/ClassStudentManagement.tsx
+++ b/src/pages/Class/ClassStudentManagement.tsx
@@ -1,0 +1,55 @@
+import { useParams } from 'react-router-dom';
+
+import {
+  useClassStudentListQuery,
+  useClassTaListQuery,
+  useCreateStudentListMutation,
+  useCreateTaListMutation,
+  useStudentForm,
+} from './hooks';
+import { ClassStudentForm } from './components';
+
+export function ClassStudentManagement() {
+  const { id: classId } = useParams() as { id: string };
+
+  const {
+    data: { results: studentList },
+  } = useClassStudentListQuery(classId);
+  const {
+    data: { results: taList },
+  } = useClassTaListQuery(classId);
+
+  const { mutate: createStudentList } = useCreateStudentListMutation();
+  const { mutate: createTatList } = useCreateTaListMutation();
+
+  const { defaultValue: defaultStudentList, onSubmit: onStudentSubmit } = useStudentForm({
+    studentList,
+    classId,
+    api: createStudentList,
+  });
+
+  const { defaultValue: defaultTaList, onSubmit: onTaSubmit } = useStudentForm({
+    studentList: taList,
+    classId,
+    api: createTatList,
+  });
+
+  return (
+    <div className="flex gap-4 justify-center flex-col sm:flex-row">
+      <ClassStudentForm
+        id="student"
+        label="학생 등록"
+        placeholder="수강생을 등록하세요"
+        defaultValue={defaultStudentList}
+        onSubmit={onStudentSubmit}
+      />
+      <ClassStudentForm
+        id="ta"
+        label="TA 등록"
+        placeholder="TA를 등록하세요"
+        defaultValue={defaultTaList}
+        onSubmit={onTaSubmit}
+      />
+    </div>
+  );
+}

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -24,4 +24,42 @@ const deleteClass = (classId: string) => {
   return api.delete(`${API_URL}/${classId}`);
 };
 
-export { getClassList, editClassList, getClass, editClass, deleteClass };
+const getClassStudentList = (classId: string) => {
+  return api.get(`${API_URL}/${classId}/std/`);
+};
+
+const getClassTaList = (classId: string) => {
+  return api.get(`${API_URL}/${classId}/ta/`);
+};
+
+const createClassStudentList = ({
+  classId,
+  payload,
+}: {
+  classId: string;
+  payload: ClassStudentRequest;
+}) => {
+  return api.post(`${API_URL}/${classId}/std/`, payload);
+};
+
+const createClassTaList = ({
+  classId,
+  payload,
+}: {
+  classId: string;
+  payload: ClassStudentRequest;
+}) => {
+  return api.post(`${API_URL}/${classId}/ta/`, payload);
+};
+
+export {
+  getClassList,
+  editClassList,
+  getClass,
+  editClass,
+  deleteClass,
+  getClassStudentList,
+  getClassTaList,
+  createClassStudentList,
+  createClassTaList,
+};

--- a/src/pages/Class/components/ClassStudentForm.tsx
+++ b/src/pages/Class/components/ClassStudentForm.tsx
@@ -1,0 +1,32 @@
+import { Button, Label } from '@/components';
+
+type ClassStudentFormProps<T extends React.ElementType> = Component<T> & {
+  id: string;
+  label: string;
+  placeholder: string;
+};
+
+export function ClassStudentForm({
+  id,
+  label,
+  placeholder,
+  defaultValue,
+  ...props
+}: ClassStudentFormProps<'form'>) {
+  return (
+    <form className="flex flex-col gap-3" {...props}>
+      <Label htmlFor={id} className="text-xl font-bold">
+        {label}
+      </Label>
+      <textarea
+        id={id}
+        cols={35}
+        rows={15}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        className="p-4 border-2 border-gray-300 rounded-lg resize-none"
+      />
+      <Button>등록</Button>
+    </form>
+  );
+}

--- a/src/pages/Class/components/index.ts
+++ b/src/pages/Class/components/index.ts
@@ -1,1 +1,2 @@
 export * from './ClassEditModal';
+export * from './ClassStudentForm';

--- a/src/pages/Class/hooks/index.ts
+++ b/src/pages/Class/hooks/index.ts
@@ -3,3 +3,5 @@ export * from './query';
 export * from './useClassListTable';
 export * from './useClassListEditTable';
 export * from './useModalBody';
+
+export * from './useStudentForm';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -4,3 +4,8 @@ export * from './useEditClassListMutation';
 export * from './useClassQuery';
 export * from './useEditClassMutation';
 export * from './useDeleteClassMutation';
+
+export * from './useClassStudentListQuery';
+export * from './useClassTaListQuery';
+export * from './useClassStudentListMutation';
+export * from './useClassTaListMutation';

--- a/src/pages/Class/hooks/query/useClassStudentListMutation.ts
+++ b/src/pages/Class/hooks/query/useClassStudentListMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createClassStudentList } from '../../api';
+
+type useCreateStudentListProps = { classId: string; payload: ClassStudentRequest };
+
+export const useCreateStudentListMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useCreateStudentListProps>
+) => {
+  return useMutation(({ classId, payload }) => createClassStudentList({ classId, payload }), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useClassStudentListQuery.ts
+++ b/src/pages/Class/hooks/query/useClassStudentListQuery.ts
@@ -1,0 +1,28 @@
+import { QueryKey, UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { QUERY_KEYS } from '@/constants';
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+
+import { getClassStudentList } from '../../api';
+
+export const useClassStudentListQuery = (
+  classId: QueryKey,
+  options?: UseQueryOptions<
+    ClassStudentListResponse,
+    AxiosError,
+    ClassStudentListResponse,
+    QueryKey[]
+  >
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_STUDENT, classId],
+    async ({ queryKey: [, classId] }) => {
+      const { data } = await getClassStudentList(String(classId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/query/useClassTaListMutation.ts
+++ b/src/pages/Class/hooks/query/useClassTaListMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createClassTaList } from '../../api';
+
+type useCreateTatListProps = { classId: string; payload: ClassStudentRequest };
+
+export const useCreateTaListMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useCreateTatListProps>
+) => {
+  return useMutation(({ classId, payload }) => createClassTaList({ classId, payload }), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useClassTaListQuery.ts
+++ b/src/pages/Class/hooks/query/useClassTaListQuery.ts
@@ -1,0 +1,28 @@
+import { QueryKey, UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { QUERY_KEYS } from '@/constants';
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+
+import { getClassTaList } from '../../api';
+
+export const useClassTaListQuery = (
+  classId: QueryKey,
+  options?: UseQueryOptions<
+    ClassStudentListResponse,
+    AxiosError,
+    ClassStudentListResponse,
+    QueryKey[]
+  >
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_TA, classId],
+    async ({ queryKey: [, classId] }) => {
+      const { data } = await getClassTaList(String(classId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/useStudentForm.ts
+++ b/src/pages/Class/hooks/useStudentForm.ts
@@ -1,0 +1,35 @@
+import { UseMutateFunction } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+type useStudentFormProps = {
+  studentList: ClassStudentList;
+  classId: string;
+  api: UseMutateFunction<
+    AxiosResponse<any, any>,
+    AxiosError<unknown, any>,
+    useCreateStudentListProps,
+    unknown
+  >;
+};
+
+type useCreateStudentListProps = { classId: string; payload: ClassStudentRequest };
+
+export const useStudentForm = ({ studentList, classId, api }: useStudentFormProps) => {
+  const defaultValue = studentList.map((student) => student?.username).join('');
+
+  const handleStudentSubmit = (
+    e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }
+  ) => {
+    e.preventDefault();
+
+    const [value] = Object.values(e.target).map(({ value }) => value as string);
+    const payload = { username: value.split('\n') };
+
+    api({ classId, payload });
+  };
+
+  return {
+    defaultValue,
+    onSubmit: handleStudentSubmit,
+  };
+};

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -1,2 +1,3 @@
 export * from './ClassList';
 export * from './ClassListEdit';
+export * from './ClassStudentManagement';

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -30,3 +30,14 @@ type ClassResponse = {
   semester: number;
   created_user: string;
 };
+
+type ClassStudentList = {
+  username: string;
+  privilege: number;
+}[];
+
+type ClassStudentListResponse = ApiResponse<ClassStudentList>;
+
+type ClassStudentRequest = {
+  username: string[];
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Resolve: #42 

## 구현 기능

- 수강생, TA 조회
- 수강생, TA 등록

## 스크린샷

<!--해당 PR에 대한 이미지 -->

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/216870746-43d6b872-33b5-4189-b574-d7426e7d5b4f.png">


## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

-  수강생, TA 조회 응답 형식에 관해서 백엔드와 논의가 필요해보입니다~
   - 수강생, TA가 results 배열에 담겨서 옴
- 응답 코드에 대해서도 논의가 필요
  - 존재하지 않는 사용자를 등록해도 201 코드 전송