### PR TITLE
[feat] 비밀번호 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from './pages/Home';
 import { Login, Register, Faq, Admin, ClassList } from '@/pages';
 import { MainHeader } from '@/components';
 import { PATH } from '@/constants';
+import ResetPassword from './pages/User/ResetPassword';
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
             <Route path={PATH.HOME} element={<Home />} />
             <Route path={PATH.LOGIN} element={<Login />} />
             <Route path={PATH.REGISTER} element={<Register />} />
+            <Route path={PATH.RESET_PASSWORD} element={<ResetPassword />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
             <Route path={PATH.CLASS_LIST} element={<ClassList />} />
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -3,6 +3,7 @@ export const BASE_PATH: { [key: string]: string } = {
 
   LOGIN: '/login',
   REGISTER: '/register',
+  RESET_PASSWORD: '/reset-password',
 
   COMPETITION: '/competition',
   CLASS: '/class',
@@ -11,6 +12,7 @@ export const BASE_PATH: { [key: string]: string } = {
   FAQ: '/faq',
 
   ADMIN: '/admin',
+  USER_HOME: '/users',
 };
 
 const SUB_PATH = {
@@ -53,6 +55,7 @@ export const PATH: { [key: string]: string } = {
 export const PAGE: { [key: string]: string } = {
   LOGIN: '로그인',
   REGISTER: '회원가입',
+  RESET_PASSWORD: '비밀번호 재설정',
 
   CLASS_LIST: '수업 및 시험',
 };

--- a/src/pages/User/Login.tsx
+++ b/src/pages/User/Login.tsx
@@ -1,15 +1,16 @@
 import { ErrorMessage, Heading } from '@/components';
 import { PAGE } from '@/constants';
 
-import { useAuthForm, useLogin } from './hooks';
+import { useAuthForm } from './hooks';
 import { AuthForm } from './components';
 import { LOGIN_ERROR } from './constants';
+import { useLoginMutation } from './hooks/query';
 
 const MODE = 'login';
 
 export default function Login() {
   const inputList = useAuthForm(MODE);
-  const { mutate, isError } = useLogin();
+  const { mutate, isError } = useLoginMutation();
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/pages/User/Register.tsx
+++ b/src/pages/User/Register.tsx
@@ -1,15 +1,16 @@
 import { ErrorMessage, Heading } from '@/components';
 import { PAGE } from '@/constants';
 
-import { useAuthForm, useRegister } from './hooks';
+import { useAuthForm } from './hooks';
 import { AuthForm } from './components';
 import { REGISTER_ERROR } from './constants';
+import { useRegisterMutation } from './hooks/query';
 
 const MODE = 'register';
 
 export default function Register() {
   const inputList = useAuthForm(MODE);
-  const { mutate, isError } = useRegister();
+  const { mutate, isError } = useRegisterMutation();
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/pages/User/ResetPassword.tsx
+++ b/src/pages/User/ResetPassword.tsx
@@ -1,0 +1,35 @@
+import { ErrorMessage, Heading } from '@/components';
+import { PAGE } from '@/constants';
+import { ResetPasswordForm } from './components/ResetPasswordForm';
+import { RESETPASSWORD_ERROR } from './constants';
+import { useResetPasswordForm } from './hooks';
+import { useResetPasswordMutation } from './hooks/query/useResetPasswordMutation';
+
+export default function ResetPassword() {
+  const inputList = useResetPasswordForm();
+  const { mutate, isError } = useResetPasswordMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const [currentPassword, newPassword, newPasswordCheck] = Object.values(inputList).map(
+      ({ value }) => value
+    );
+
+    mutate({
+      current_password: currentPassword,
+      new_password: newPassword,
+      new_password2: newPasswordCheck,
+    });
+  };
+
+  return (
+    <div className="container max-w-md mx-auto">
+      <Heading className="text-2xl font-bold">{PAGE['RESET_PASSWORD']}</Heading>
+      <ResetPasswordForm inputList={inputList} onSubmit={handleFormSubmit} />
+      {isError && (
+        <ErrorMessage className="mt-4">{RESETPASSWORD_ERROR.RESET_PASSWORD_FAILED}</ErrorMessage>
+      )}
+    </div>
+  );
+}

--- a/src/pages/User/api/index.ts
+++ b/src/pages/User/api/index.ts
@@ -5,11 +5,16 @@ import { api } from '@/api';
 const API_URL = `/users/`;
 
 const loginUser = (payload: User): Promise<AxiosResponse<LoginResponse>> => {
-  return api.post(`${API_URL}/login`, payload);
+  return api.post(`${API_URL}/login/`, payload);
 };
 
 const registerUser = (payload: RegisterRequest): Promise<AxiosResponse> => {
   return api.post(`${API_URL}`, payload);
 };
 
-export { loginUser, registerUser };
+const resetPassword = (payload: ResetPasswordRequest): Promise<AxiosResponse> => {
+  // Todo: 전역 username 가져오도록 변경하기
+  return api.patch(`${API_URL}/{username}/`, payload);
+};
+
+export { loginUser, registerUser, resetPassword };

--- a/src/pages/User/components/ResetPasswordForm.tsx
+++ b/src/pages/User/components/ResetPasswordForm.tsx
@@ -1,0 +1,34 @@
+import { Label, Input, Button, ErrorMessage } from '@/components';
+import { PAGE } from '@/constants';
+
+import { INPUT, RESETPASSWORD_ERROR } from '../constants';
+import { useResetPasswordForm } from '../hooks';
+
+type ResetPasswordFormProps = {
+  inputList: ReturnType<typeof useResetPasswordForm>;
+  onSubmit: (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => void;
+};
+
+export function ResetPasswordForm({ inputList, onSubmit }: ResetPasswordFormProps) {
+  const isFormValid = Object.values(inputList).every(({ value, error }) => value && !error);
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {Object.entries(inputList).map(([key, { type, value, error, handleInputChange }]) => (
+        <>
+          <Label htmlFor={key}>{INPUT[key.toUpperCase()]}</Label>
+          <Input
+            type={type}
+            id={key === 'NEWPASSWORDCHECK' ? 'PASSWORDCHECK' : 'PASSWORD'}
+            value={value}
+            onChange={(e) => {
+              handleInputChange(e, inputList.newPassword.value);
+            }}
+          />
+          {error && <ErrorMessage>{RESETPASSWORD_ERROR[key.toUpperCase()]}</ErrorMessage>}
+        </>
+      ))}
+      <Button disabled={!isFormValid}>{PAGE['RESET_PASSWORD']}</Button>
+    </form>
+  );
+}

--- a/src/pages/User/constants/errorMessage.ts
+++ b/src/pages/User/constants/errorMessage.ts
@@ -11,3 +11,10 @@ export const REGISTER_ERROR: { [key: string]: string } = {
   PASSWORDCHECK: '비밀번호와 일치하지 않습니다.',
   REGISTER_FAILED: '가입에 실패하였습니다.',
 };
+
+export const RESETPASSWORD_ERROR: { [key: string]: string } = {
+  CURRENTPASSWORD: '비밀번호는 영문자, 숫자 포함 8자 이상입니다.',
+  NEWPASSWORD: '비밀번호는 영문자, 숫자 포함 8자 이상입니다.',
+  NEWPASSWORDCHECK: '비밀번호와 일치하지 않습니다.',
+  RESET_PASSWORD_FAILED: '비밀번호 변경에 실패하였습니다.',
+};

--- a/src/pages/User/constants/input.ts
+++ b/src/pages/User/constants/input.ts
@@ -4,4 +4,7 @@ export const INPUT: { [key: string]: string } = {
   USERNAME: '아이디',
   PASSWORD: '비밀번호',
   PASSWORDCHECK: '비밀번호 확인',
+  CURRENTPASSWORD: '현재 비밀번호',
+  NEWPASSWORD: '새로운 비밀번호',
+  NEWPASSWORDCHECK: '새로운 비밀번호 확인',
 };

--- a/src/pages/User/hooks/index.ts
+++ b/src/pages/User/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useInput';
 export * from './useAuthForm';
+export * from './useResetPasswordForm';

--- a/src/pages/User/hooks/index.ts
+++ b/src/pages/User/hooks/index.ts
@@ -1,4 +1,2 @@
 export * from './useInput';
-export * from './useLogin';
-export * from './useRegister';
 export * from './useAuthForm';

--- a/src/pages/User/hooks/query/index.ts
+++ b/src/pages/User/hooks/query/index.ts
@@ -1,0 +1,3 @@
+export * from './useLoginMutation';
+export * from './useRegisterMutation';
+export * from './useResetPasswordMutation';

--- a/src/pages/User/hooks/query/useLoginMutation.ts
+++ b/src/pages/User/hooks/query/useLoginMutation.ts
@@ -6,9 +6,9 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { AuthContext } from '@/contexts';
 import { STORAGE, PATH } from '@/constants';
 
-import { loginUser } from '../api';
+import { loginUser } from '../../api';
 
-export const useLogin = (
+export const useLoginMutation = (
   options?: UseMutationOptions<AxiosResponse<LoginResponse>, AxiosError, User>
 ) => {
   const { setIsLogin } = useContext(AuthContext);

--- a/src/pages/User/hooks/query/useRegisterMutation.ts
+++ b/src/pages/User/hooks/query/useRegisterMutation.ts
@@ -4,9 +4,9 @@ import { AxiosError, AxiosResponse } from 'axios';
 
 import { PATH } from '@/constants';
 
-import { registerUser } from '../api';
+import { registerUser } from '../../api';
 
-export const useRegister = (
+export const useRegisterMutation = (
   options?: UseMutationOptions<AxiosResponse, AxiosError, RegisterRequest>
 ) => {
   const navigate = useNavigate();

--- a/src/pages/User/hooks/query/useResetPasswordMutation.ts
+++ b/src/pages/User/hooks/query/useResetPasswordMutation.ts
@@ -1,0 +1,17 @@
+import { PATH } from '@/constants';
+import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation, UseMutationOptions } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { resetPassword } from '../../api';
+
+export const useResetPasswordMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, ResetPasswordRequest>
+) => {
+  const navigate = useNavigate();
+  return useMutation((password) => resetPassword(password), {
+    ...options,
+    onSuccess: () => {
+      navigate(PATH.USER_HOME);
+    },
+  });
+};

--- a/src/pages/User/hooks/useResetPasswordForm.ts
+++ b/src/pages/User/hooks/useResetPasswordForm.ts
@@ -1,0 +1,29 @@
+import { REGEXP } from '../constants';
+import { useInput } from './useInput';
+
+const passwordInput = {
+  type: 'password',
+  required: true,
+};
+
+export const useResetPasswordForm = () => {
+  const resetPasswordForm = {
+    currentPassword: {
+      ...passwordInput,
+      ...useInput(),
+      regexp: REGEXP['PASSWORD'],
+    },
+    newPassword: {
+      ...passwordInput,
+      ...useInput(),
+      regexp: REGEXP['PASSWORD'],
+    },
+    newPasswordCheck: {
+      ...passwordInput,
+      ...useInput(),
+      regexp: REGEXP['PASSWORD'],
+    },
+  };
+
+  return resetPasswordForm;
+};

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -37,3 +37,9 @@ type AdminUserResponse = {
   date_joined: string;
   is_active: boolean;
 };
+
+type ResetPasswordRequest = {
+  current_password: string;
+  new_password: string;
+  new_password2: string;
+};


### PR DESCRIPTION
## 이슈 번호
* Resolve: #44 

## 구현 기능
* 비밀번호 변경

## 변경 로직
* 기존 로그인과 회원가입 mutation 폴더 구조 및 파일 이름 변경
  * hooks > query 이동
  * 기존 파일명에 Mutation추가하여 변경

## 스크린샷
<img width="867" alt="image" src="https://user-images.githubusercontent.com/63294532/216884984-7eceda47-6b95-4f1d-bf8e-368b1484d3dd.png">


## 참고 사항
* API path에 필요한 username 전역으로 관리한 후 수정이 필요합니다.
* 상황별 에러처리가 필요합니다. 현재는 API 응답으로 오는 에러는 `비밀번호를 변경할 수 없습니다`로 통일되어있습니다.
