### PR TITLE
[feat] 관리자페이지 - 전체 수업 목록

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,18 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq, Admin, ClassList, Class, ClassProblemList } from '@/pages';
+import {
+  Login,
+  Register,
+  Faq,
+  Admin,
+  ClassList,
+  Class,
+  ClassProblemList,
+  AdminAllClasses,
+  AdminAllProblems,
+} from '@/pages';
 import { MainHeader } from '@/components';
-import { AdminAllProblems } from './pages/Admin';
 import { PATH, SUB_PATH } from '@/constants';
 
 export default function App() {
@@ -28,7 +37,7 @@ export default function App() {
             <Route path={PATH.FAQ} element={<Faq />} />
             <Route path={PATH.ADMIN} element={<Admin />}>
               <Route path={PATH.ADMIN_ALL_PROBLEMS} element={<AdminAllProblems />} />
-              <Route path={PATH.ADMIN_ALL_CLASSES} element={<div>AllClasses</div>} />
+              <Route path={PATH.ADMIN_ALL_CLASSES} element={<AdminAllClasses />} />
               <Route path={PATH.ADMIN_ANNOUNCEMENTS} element={<div>Announcements</div>} />
               <Route path={PATH.ADMIN_FAQS} element={<div>FAQs</div>} />
               <Route path={PATH.ADMIN_USER_MANAGEMENT} element={<div>UserManagement</div>} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -60,6 +60,7 @@ export const PAGE: { [key: string]: string } = {
   CLASS_ALL_PROBLEMS: '전체 문제 목록',
   CLASS_STUDENT_MANAGEMENT: '수강생 및 TA 관리',
   CLASS_CONTEST: '과제 및 시험',
-  
+
   ALL_PROBLEMS: '전체 문제 목록',
+  ALL_CLASSES: '전체 수업 목록',
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,6 +1,7 @@
 export const QUERY_KEYS = {
   ADMIN_USER_EDIT: 'admin-user-edit',
   ADMIN_ALL_PROBLEMS: 'admin-all-problems',
+  ADMIN_ALL_CLASSES: 'admin-all-classes',
   FAQ: 'faq',
   ANNOUNCEMENT: 'announcement',
   CLASS: 'class',

--- a/src/pages/Admin/AdminAllClasses.tsx
+++ b/src/pages/Admin/AdminAllClasses.tsx
@@ -1,0 +1,28 @@
+import { Heading, Input, Table } from '@/components';
+import { PAGE } from '@/constants/paths';
+import { useSearch } from '@/hooks/useSearch';
+import { useAdminAllClassesTable } from './hooks';
+
+export function AdminAllClasses() {
+  const { keyword, onChange } = useSearch();
+  const { column, data, handleRowClick } = useAdminAllClassesTable(keyword);
+
+  return (
+    <>
+      <div className="flex flex-row justify-between">
+        <Heading as="h3" className="pageTitle">
+          {PAGE.ALL_CLASSES}
+        </Heading>
+        <div className="py-10 w-1/3">
+          <Input
+            type="search"
+            className="h-10 w-full"
+            placeholder="검색"
+            onChange={onChange}
+          ></Input>
+        </div>
+      </div>
+      <Table column={column} data={data} onRowClick={handleRowClick} />
+    </>
+  );
+}

--- a/src/pages/Admin/AdminAllProblems.tsx
+++ b/src/pages/Admin/AdminAllProblems.tsx
@@ -1,7 +1,7 @@
 import { Heading, Input, Table } from '@/components';
 import { PAGE } from '@/constants/paths';
 import { useState } from 'react';
-import { useAdminAllProblemsTable } from './hooks/useAdminAllProblemsTable';
+import { useAdminAllProblemsTable } from './hooks';
 
 export function AdminAllProblems() {
   const [keyword, setKeyword] = useState('');

--- a/src/pages/Admin/api/index.ts
+++ b/src/pages/Admin/api/index.ts
@@ -23,4 +23,8 @@ const deleteProblem = (problemId: string) => {
   return api.delete(`/problems/${problemId}`);
 };
 
-export { getUser, editUserPrivilege, getProblems, deleteProblem };
+const getClasses = (keyword: string): Promise<AxiosResponse<AdminAllClassesResponse>> => {
+  return api.get(`${API_URL}/class?keyword=${keyword}`);
+};
+
+export { getUser, editUserPrivilege, getProblems, deleteProblem, getClasses };

--- a/src/pages/Admin/hooks/index.ts
+++ b/src/pages/Admin/hooks/index.ts
@@ -1,2 +1,4 @@
 export * from './useModalBody';
 export * from './useSelectUserPrivilege';
+export * from './useAdminAllClassesTable';
+export * from './useAdminAllProblemsTable';

--- a/src/pages/Admin/hooks/query/index.ts
+++ b/src/pages/Admin/hooks/query/index.ts
@@ -1,2 +1,4 @@
 export * from './useUserQuery';
 export * from './useEditUserPrivilegeMutation';
+export * from './useAdminAllClassesQuery';
+export * from './useAdminAllProblemsQuery';

--- a/src/pages/Admin/hooks/query/useAdminAllClassesQuery.ts
+++ b/src/pages/Admin/hooks/query/useAdminAllClassesQuery.ts
@@ -1,0 +1,27 @@
+import { UseQueryOptions } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { QUERY_KEYS } from '@/constants';
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { getClasses } from '../../api';
+
+export const useAdminAllClassesQuery = (
+  keyword: string,
+  options?: UseQueryOptions<
+    AdminAllClassesResponse,
+    AxiosError,
+    AdminAllClassesResponse,
+    [string, string]
+  >
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.ADMIN_ALL_CLASSES, keyword],
+    async ({ queryKey: [, keyword] }) => {
+      const { data } = await getClasses(keyword);
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Admin/hooks/useAdminAllClassesTable.ts
+++ b/src/pages/Admin/hooks/useAdminAllClassesTable.ts
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/paths';
+import React from 'react';
+import { useAdminAllClassesQuery } from './query';
+
+export const useAdminAllClassesTable = (keyword: string) => {
+  const navigate = useNavigate();
+
+  const handleRowClick = (
+    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    id: number | string
+  ) => {
+    navigate(`${PATH.CLASS}/${id}/contest`);
+  };
+
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: '연도', accessor: 'year' },
+    { Header: '학기', accessor: 'semester' },
+    { Header: '수업이름', accessor: 'name' },
+    { Header: '수업 생성자', accessor: 'created_user' },
+  ];
+
+  const {
+    data: { results },
+  } = useAdminAllClassesQuery(keyword);
+
+  const data = results;
+
+  return { column, data, handleRowClick };
+};

--- a/src/pages/Admin/hooks/useAdminAllProblemsTable.tsx
+++ b/src/pages/Admin/hooks/useAdminAllProblemsTable.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom';
-import { useAdminAllProblemsQuery } from './query/useAdminAllProblemsQuery';
 import { Button } from '@/components';
 import { useDeleteProblemMutation } from './query/useDeleteProblemMutation';
 import { PATH } from '@/constants/paths';
 import React from 'react';
+import { useAdminAllProblemsQuery } from './query';
 
 export const useAdminAllProblemsTable = (keyword: string) => {
   const navigate = useNavigate();

--- a/src/pages/Admin/index.ts
+++ b/src/pages/Admin/index.ts
@@ -1,2 +1,3 @@
 export * from './Admin';
 export * from './AdminAllProblems';
+export * from './AdminAllClasses';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -4,3 +4,5 @@ export * from './useEditClassListMutation';
 export * from './useClassQuery';
 export * from './useEditClassMutation';
 export * from './useDeleteClassMutation';
+
+export * from './useProblemListQuery';

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -7,9 +7,24 @@ type AdminAllProblems = {
   class_id: number;
 };
 
+type AdminAllClasses = {
+  id: number;
+  name: string;
+  year: number;
+  semester: number;
+  created_user: string;
+};
+
 type AdminAllProblemsResponse = {
   count: number;
   next: number | null;
   previous: number | nulle;
   results: AdminAllProblems[];
+};
+
+type AdminAllClassesResponse = {
+  count: number;
+  next: number | null;
+  previous: number | nulle;
+  results: AdminAllClasses[];
 };


### PR DESCRIPTION
## 이슈 번호
* Resolve: #46 

## 구현 기능
* 전체 수업 목록 조회
* 수업 검색
* 수업 클릭시 해당 수업 상세 정보(`/class/:id/contest`)로 이동

## 변경 로직
* query폴더 index로 export하여 기존 전체 문제 목록에서 import 하던 부분 path 수정하였습니다.

## 스크린샷
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/63294532/216897474-ef9ba8da-870f-42b1-a8ed-e3deb1caae27.png">

## 참고 사항
* 페이지네이션은 백엔드와 상의 후 구현이 필요합니다.
