### PR TITLE
feat: 수업 페이지 - 과제 및 시험

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,17 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq, Admin, ClassList, Class, ClassProblemList } from '@/pages';
+import {
+  Login,
+  Register,
+  Faq,
+  Admin,
+  ClassList,
+  Class,
+  ClassProblemList,
+  ClassContest,
+  ClassContestProblemList,
+} from '@/pages';
 import { MainHeader } from '@/components';
 import { AdminAllProblems } from './pages/Admin';
 import { PATH, SUB_PATH } from '@/constants';
@@ -19,10 +29,13 @@ export default function App() {
             <Route path={PATH.LOGIN} element={<Login />} />
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
-            <Route path={PATH.CLASS_LIST} element={<ClassList />} />
-            <Route path={PATH.CLASS_DETAIL} element={<Class />}>
+            <Route path={`${PATH.CLASS_DETAIL}/*`} element={<Class />}>
               <Route path={SUB_PATH.ALL_PROBLEMS} element={<ClassProblemList />} />
+              <Route path={SUB_PATH.CONTEST} element={<ClassContest />}>
+                <Route path={SUB_PATH.CONTEST_DETAIL} element={<ClassContestProblemList />} />
+              </Route>
             </Route>
+            <Route path={PATH.CLASS_LIST} element={<ClassList />}></Route>
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
             <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />
             <Route path={PATH.FAQ} element={<Faq />} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -24,8 +24,10 @@ export const SUB_PATH = {
   ANNOUNCEMENTS: 'announcements',
   FAQS: 'faqs',
   USER_MANAGEMENT: 'user-management',
+
   STUDENT_MANAGEMENT: 'student-management',
   CONTEST: 'contest',
+  CONTEST_DETAIL: ':contestId',
 };
 
 export const PATH: { [key: string]: string } = {
@@ -42,7 +44,7 @@ export const PATH: { [key: string]: string } = {
 
   CLASS_LIST: `${BASE_PATH.CLASS}`,
   CLASS_LIST_EDIT: `${BASE_PATH.CLASS}/edit-class`,
-  CLASS_DETAIL: `${BASE_PATH.CLASS}/:id`,
+  CLASS_DETAIL: `${BASE_PATH.CLASS}/:classId`,
   CLASS_FORM: `${BASE_PATH.CLASS}/form`,
 
   ADMIN_ALL_PROBLEMS: `${BASE_PATH.ADMIN}/${SUB_PATH.ALL_PROBLEMS}`,
@@ -60,6 +62,6 @@ export const PAGE: { [key: string]: string } = {
   CLASS_ALL_PROBLEMS: '전체 문제 목록',
   CLASS_STUDENT_MANAGEMENT: '수강생 및 TA 관리',
   CLASS_CONTEST: '과제 및 시험',
-  
+
   ALL_PROBLEMS: '전체 문제 목록',
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -5,4 +5,5 @@ export const QUERY_KEYS = {
   ANNOUNCEMENT: 'announcement',
   CLASS: 'class',
   CLASS_PROBLEM: 'class-problem',
+  CLASS_CONTEST: 'class-contest',
 };

--- a/src/pages/Class/Class.tsx
+++ b/src/pages/Class/Class.tsx
@@ -6,10 +6,10 @@ import { PAGE, SUB_PATH } from '@/constants';
 import { useClassQuery } from './hooks';
 
 export function Class() {
-  const { id } = useParams();
+  const { classId } = useParams();
   const {
     data: { name },
-  } = useClassQuery(id as string);
+  } = useClassQuery(classId as string);
 
   const menuList = [
     { name: PAGE.CLASS_ALL_PROBLEMS, to: SUB_PATH.ALL_PROBLEMS },

--- a/src/pages/Class/ClassContest.tsx
+++ b/src/pages/Class/ClassContest.tsx
@@ -1,0 +1,27 @@
+import { useParams, Outlet } from 'react-router-dom';
+
+import { Header } from '@/components';
+
+import { useClassContestListQuery } from './hooks';
+
+export function ClassContest() {
+  const { classId } = useParams() as { classId: string };
+  const {
+    data: { results },
+  } = useClassContestListQuery(classId);
+  const menuList = results.map(({ id, name }) => ({ name, to: `${id}` }));
+
+  return (
+    <div className="grid gap-4 grid-cols-none sm:grid-cols-6">
+      <Header className="py-2 row-span-1 sm:col-span-1">
+        <Header.MenuList
+          menuList={menuList}
+          className="flex items-center justify-center gap-4 flex-col"
+        />
+      </Header>
+      <section className="sm:col-span-5">
+        <Outlet />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Class/ClassContestProblemList.tsx
+++ b/src/pages/Class/ClassContestProblemList.tsx
@@ -1,0 +1,24 @@
+import { useParams } from 'react-router-dom';
+
+import { Button, Heading, Table } from '@/components';
+import { useContestProblemListTable, useClassContestListQuery } from './hooks';
+
+export function ClassContestProblemList() {
+  const { classId, contestId } = useParams() as { classId: string; contestId: string };
+  const {
+    data: { results },
+  } = useClassContestListQuery(classId);
+  const title = results.find(({ id }) => id === +contestId)?.name;
+
+  const tableProps = useContestProblemListTable(classId, contestId);
+
+  return (
+    <>
+      <header className="flex justify-between items-center">
+        <Heading as="h3">{title}</Heading>
+        <Button>문제 생성</Button>
+      </header>
+      <Table {...tableProps} />
+    </>
+  );
+}

--- a/src/pages/Class/ClassStudentManagement.tsx
+++ b/src/pages/Class/ClassStudentManagement.tsx
@@ -10,7 +10,7 @@ import {
 import { ClassStudentForm } from './components';
 
 export function ClassStudentManagement() {
-  const { id: classId } = useParams() as { id: string };
+  const { classId } = useParams() as { classId: string };
 
   const {
     data: { results: studentList },

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -28,4 +28,21 @@ const getProblemList = ({ keyword }: { keyword: string }) => {
   return api.get(`/problems?keyword=${keyword}`);
 };
 
-export { getClassList, editClassList, getClass, editClass, deleteClass, getProblemList };
+const getContestList = (classId: string) => {
+  return api.get(`${API_URL}/${classId}/contests`);
+};
+
+const getContestProblemList = (classId: string, contestId: string) => {
+  return api.get(`${API_URL}/${classId}/contests/${contestId}`);
+};
+
+export {
+  getClassList,
+  editClassList,
+  getClass,
+  editClass,
+  deleteClass,
+  getProblemList,
+  getContestList,
+  getContestProblemList,
+};

--- a/src/pages/Class/hooks/index.ts
+++ b/src/pages/Class/hooks/index.ts
@@ -5,3 +5,5 @@ export * from './useClassListEditTable';
 export * from './useModalBody';
 
 export * from './useClassProblemListTable';
+
+export * from './useContestProblemListTable';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -6,3 +6,6 @@ export * from './useEditClassMutation';
 export * from './useDeleteClassMutation';
 
 export * from './useProblemListQuery';
+
+export * from './useClassContestListQuery';
+export * from './useClassContestProblemQuery';

--- a/src/pages/Class/hooks/query/useClassContestListQuery.ts
+++ b/src/pages/Class/hooks/query/useClassContestListQuery.ts
@@ -1,0 +1,23 @@
+import { UseQueryOptions, QueryKey } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getContestList } from '../../api';
+
+export const useClassContestListQuery = (
+  classId: QueryKey,
+  options?: UseQueryOptions<ContestListResponse, AxiosError, ContestListResponse, QueryKey[]>
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_CONTEST, classId],
+    async ({ queryKey: [, classId] }) => {
+      const { data } = await getContestList(String(classId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/query/useClassContestProblemQuery.ts
+++ b/src/pages/Class/hooks/query/useClassContestProblemQuery.ts
@@ -1,0 +1,29 @@
+import { UseQueryOptions, QueryKey } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getContestProblemList } from '../../api';
+
+export const useClassContestProblemListQuery = (
+  classId: QueryKey,
+  contestId: QueryKey,
+  options?: UseQueryOptions<
+    ContestProblemListResponse,
+    AxiosError,
+    ContestProblemListResponse,
+    QueryKey[]
+  >
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_CONTEST, classId, contestId],
+    async ({ queryKey: [, classId, contestId] }) => {
+      const { data } = await getContestProblemList(String(classId), String(contestId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/hooks/useContestProblemListTable.tsx
+++ b/src/pages/Class/hooks/useContestProblemListTable.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@/components';
+
+import { useClassContestProblemListQuery } from './query';
+import { formatTime } from '@/utils/time';
+
+export const useContestProblemListTable = (classId: string, contestId: string) => {
+  const navigate = useNavigate();
+
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: '제목', accessor: 'title' },
+    { Header: '마감기한', accessor: 'endTime' },
+    { Header: '편집', accessor: 'edit' },
+    { Header: '삭제', accessor: 'delete' },
+  ];
+
+  const {
+    data: { results },
+  } = useClassContestProblemListQuery(classId, contestId);
+  const data = results.map((problem) => ({
+    ...problem,
+    endTime: formatTime(problem.end_time),
+    edit: <Button>편집</Button>,
+    delete: <Button>삭제</Button>,
+  }));
+
+  const handleRowClick = (
+    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    id: number | string
+  ) => {
+    /** FIXME: 해당 문제 상세 페이지로 이동하게 수정 */
+    navigate(`${id}`);
+  };
+
+  return {
+    column,
+    data,
+    onRowClick: handleRowClick,
+  };
+};

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -2,3 +2,5 @@ export * from './ClassList';
 export * from './ClassListEdit';
 export * from './Class';
 export * from './ClassProblemList';
+export * from './ClassContest';
+export * from './ClassContestProblemList';

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -36,3 +36,27 @@ type ProblemList = {
 }[];
 
 type ProblemListResponse = ApiResponse<ProblemList>;
+
+type ContestList = {
+  id: number;
+  class_id: number;
+  name: string;
+  is_exam: boolean;
+  visible: boolean;
+  start_time: string;
+  end_time: string;
+}[];
+
+type ContestListResponse = ApiResponse<ContestList>;
+
+type ContestProblemList = {
+  id: number;
+  contest_id: number;
+  problem_id: number;
+  title: string;
+  start_time: string;
+  end_time: string;
+  order: number;
+}[];
+
+type ContestProblemListResponse = ApiResponse<ContestProblemList>;


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to : #50 

## 구현 기능

- contest 사이드바
- contest 문제 조회

## 변경 로직

- Class 관련 Route 수정
  - classId, contestId params를 모두 사용하기 위해 수정
  - 수정하지 않을 경우, 현재 path에 있는 params만 이용 가능

## 스크린샷

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217149324-f16b9ba7-2b76-40b9-9562-ee4b63698874.png">


<!--해당 PR에 대한 이미지 -->

## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- 생성 / 편집은 문제 상세 페이지가 구현된 후에 구현할 예정입니다
- Table Row 클릭했을 때 문제 상세페이지로 이동하게 수정해야합니다.