### PR TITLE
feat: 수업 - 전체 문제 상세 조회, 문제 생성폼

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,21 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq, Admin, ClassList, Class, ClassProblemList } from '@/pages';
+import {
+  Login,
+  Register,
+  Faq,
+  Admin,
+  ClassList,
+  Class,
+  ClassProblemList,
+  ProblemDescription,
+  ProblemData,
+  ProblemLeaderBoard,
+  ProblemSubmission,
+  AllProblemDetail,
+  ProblemForm,
+} from '@/pages';
 import { MainHeader } from '@/components';
 import { AdminAllProblems } from './pages/Admin';
 import { PATH, SUB_PATH } from '@/constants';
@@ -20,8 +34,15 @@ export default function App() {
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
             <Route path={PATH.CLASS_LIST} element={<ClassList />} />
-            <Route path={PATH.CLASS_DETAIL} element={<Class />}>
+            <Route path={`${PATH.CLASS_DETAIL}/*`} element={<Class />}>
               <Route path={SUB_PATH.ALL_PROBLEMS} element={<ClassProblemList />} />
+              <Route path={SUB_PATH.PROBLEM} element={<AllProblemDetail />}>
+                <Route path={SUB_PATH.DESCRIPTION} element={<ProblemDescription />} />
+                <Route path={SUB_PATH.DATA} element={<ProblemData />} />
+                <Route path={SUB_PATH.LEADERBOARD} element={<ProblemLeaderBoard />} />
+                <Route path={SUB_PATH.SUBMISSON} element={<ProblemSubmission />} />
+              </Route>
+              <Route path={SUB_PATH.PROBLEM_CREATE} element={<ProblemForm />}></Route>
             </Route>
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
             <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from './localStorage';
 export * from './paths';
 export * from './queryKeys';
 export * from './privilege';
+export * from './metrics';

--- a/src/constants/metrics.ts
+++ b/src/constants/metrics.ts
@@ -1,0 +1,10 @@
+export const METRICS = [
+  'MSE',
+  'CategorizationAccuracy',
+  'RMSE',
+  'MAE',
+  'F1-score',
+  'Log-loss',
+  'RMSLE',
+  'mAP',
+];

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -19,6 +19,8 @@ export const SUB_PATH = {
   LEADERBOARD: 'leaderboard',
   SUBMISSON: 'submission',
 
+  PROBLEM: ':problemId',
+  PROBLEM_CREATE: 'create',
   ALL_PROBLEMS: 'all-problems',
   ALL_CLASSES: 'all-classes',
   ANNOUNCEMENTS: 'announcements',
@@ -60,6 +62,6 @@ export const PAGE: { [key: string]: string } = {
   CLASS_ALL_PROBLEMS: '전체 문제 목록',
   CLASS_STUDENT_MANAGEMENT: '수강생 및 TA 관리',
   CLASS_CONTEST: '과제 및 시험',
-  
+
   ALL_PROBLEMS: '전체 문제 목록',
 };

--- a/src/pages/Class/Problem/AllProblemDetail.tsx
+++ b/src/pages/Class/Problem/AllProblemDetail.tsx
@@ -1,0 +1,19 @@
+import { useParams } from 'react-router-dom';
+
+import { SUB_PATH } from '@/constants';
+
+import { Problem } from './components';
+import { useProblemQuery } from './hooks';
+
+export function AllProblemDetail() {
+  const { problemId } = useParams() as { id: string; problemId: string };
+
+  const { data } = useProblemQuery(problemId);
+
+  const menuList = [
+    { name: '문제 설명', to: SUB_PATH.DESCRIPTION },
+    { name: '데이터', to: SUB_PATH.DATA },
+  ];
+
+  return <Problem menuList={menuList} data={data} />;
+}

--- a/src/pages/Class/Problem/ProblemData.tsx
+++ b/src/pages/Class/Problem/ProblemData.tsx
@@ -1,0 +1,6 @@
+import { useOutletContext } from 'react-router-dom';
+
+export function ProblemData() {
+  const { data_description: dataDescription } = useOutletContext<{ data_description: string }>();
+  return <>{dataDescription}</>;
+}

--- a/src/pages/Class/Problem/ProblemDescription.tsx
+++ b/src/pages/Class/Problem/ProblemDescription.tsx
@@ -1,0 +1,6 @@
+import { useOutletContext } from 'react-router-dom';
+
+export function ProblemDescription() {
+  const { description } = useOutletContext<{ description: string }>();
+  return <>{description}</>;
+}

--- a/src/pages/Class/Problem/ProblemForm.tsx
+++ b/src/pages/Class/Problem/ProblemForm.tsx
@@ -1,0 +1,62 @@
+import { useParams } from 'react-router-dom';
+
+import { Button, Heading, Label, Input, Select, Switch } from '@/components';
+import { METRICS } from '@/constants';
+
+import { useCreateProblemMutation } from './hooks';
+
+export function ProblemForm() {
+  const options = METRICS.map((metric) => ({ value: metric }));
+  const { id: classId } = useParams() as { id: string };
+  const { mutate: createProblem } = useCreateProblemMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const formValue = Object.values(e.target)
+      .filter(({ nodeName }) => nodeName === 'INPUT' || nodeName === 'SELECT')
+      .map(({ value, files }) => (files ? files[0] : value));
+
+    const payloadKey = [
+      'title',
+      'description',
+      'evaluation',
+      'public',
+      'data_description',
+      'data',
+      'solution',
+    ];
+
+    const formData = new FormData();
+    formData.append('class_id', classId);
+    payloadKey.forEach((key, index) => formData.append(key, formValue[index]));
+
+    createProblem(formData);
+  };
+
+  return (
+    <form onSubmit={handleFormSubmit} className="flex flex-col gap-2">
+      <Heading as="h3">문제 생성</Heading>
+      <Input required placeholder="문제 이름을 입력하세요." />
+      <div>
+        <Heading as="h4">문제 설명</Heading>
+        {/* FIXME: 마크다운 */}
+        <Input required placeholder="문제 설명을 입력하세요." />
+        <Label>평가 지표</Label>
+        <Select required options={options} />
+        <Label>전체 공개</Label>
+        <Switch enabled={true} />
+      </div>
+      <div>
+        <Heading as="h4">데이터</Heading>
+        {/* FIXME: 마크다운 */}
+        <Input placeholder="데이터 설명을 입력하세요." />
+        <Label>데이터 파일</Label>
+        <Input type="file" accept=".zip" required />
+        <Label>정답 파일</Label>
+        <Input type="file" accept=".csv" required />
+      </div>
+      <Button>저장</Button>
+    </form>
+  );
+}

--- a/src/pages/Class/Problem/ProblemLeaderBoard.tsx
+++ b/src/pages/Class/Problem/ProblemLeaderBoard.tsx
@@ -1,0 +1,17 @@
+import { Table } from '@/components';
+
+export function ProblemLeaderBoard() {
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: '이름', accessor: 'name' },
+    { Header: '점수', accessor: 'score' },
+    { Header: '제출 날짜', accessor: 'time' },
+    { Header: '코드(.ipynb)', accessor: 'ipynbFile' },
+    { Header: '답안(.csv)', accessor: 'csvFile' },
+  ];
+
+  /** FIXME: 수업 상세 정보 */
+  const data = [{ id: 1 }];
+
+  return <Table column={column} data={data} />;
+}

--- a/src/pages/Class/Problem/ProblemSubmission.tsx
+++ b/src/pages/Class/Problem/ProblemSubmission.tsx
@@ -1,0 +1,34 @@
+import { Button, Heading, Table, Input } from '@/components';
+
+export function ProblemSubmission() {
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: 'csv 파일', accessor: 'csvFile' },
+    { Header: 'ipynb 파일', accessor: 'ipynbFile' },
+    { Header: '점수', accessor: 'score' },
+    { Header: 'status', accessor: 'status' },
+    { Header: '제출 날짜', accessor: 'submissionDate' },
+  ];
+  /** FIXME: 수업 상세 정보 */
+  const data = [{ id: 1 }];
+
+  return (
+    <>
+      <form className="flex flex-col gap-2 mb-10">
+        <Heading as="h4">csv 파일 제출</Heading>
+        <p>하나의 csv 파일만 업로드 가능합니다</p>
+        <Input type="file" accept=".csv" />
+
+        <Heading as="h4">ipynb 파일 제출</Heading>
+        <p>하나의 ipynb 파일만 업로드 가능합니다</p>
+        <Input type="file" accept=".ipynb" />
+
+        <Button className="inline-block">파일 제출</Button>
+      </form>
+
+      <Heading as="h4">제출 내역</Heading>
+      <p>선택한 제출 내역이 리더보드에 표시됩니다.</p>
+      <Table column={column} data={data} />
+    </>
+  );
+}

--- a/src/pages/Class/Problem/api/index.ts
+++ b/src/pages/Class/Problem/api/index.ts
@@ -1,0 +1,13 @@
+import { api, fileApi } from '@/api';
+
+const API_URL = `/problems`;
+
+const getProblem = (problemId: string) => {
+  return api.get(`${API_URL}/${problemId}`);
+};
+
+const createProblem = (payload: FormData) => {
+  return fileApi.post(`${API_URL}/`, payload);
+};
+
+export { getProblem, createProblem };

--- a/src/pages/Class/Problem/components/Problem.tsx
+++ b/src/pages/Class/Problem/components/Problem.tsx
@@ -1,0 +1,26 @@
+import { Outlet } from 'react-router-dom';
+
+import { Header, Heading } from '@/components';
+
+type ProblemProps = {
+  menuList: { name: string; to: string }[];
+  data: Problem;
+};
+
+export function Problem({ menuList, data }: ProblemProps) {
+  return (
+    <>
+      <Heading as="h3" className="pageTitle">
+        {data.title}
+      </Heading>
+      <div className="grid gap-4 grid-cols-none sm:grid-cols-6">
+        <Header className="py-2 row-span-1 sm:col-span-1">
+          <Header.MenuList menuList={menuList} />
+        </Header>
+        <section className="sm:col-span-5">
+          <Outlet context={data} />
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Class/Problem/components/index.ts
+++ b/src/pages/Class/Problem/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Problem';

--- a/src/pages/Class/Problem/hooks/index.ts
+++ b/src/pages/Class/Problem/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/src/pages/Class/Problem/hooks/query/index.ts
+++ b/src/pages/Class/Problem/hooks/query/index.ts
@@ -1,0 +1,2 @@
+export * from './useProblemQuery';
+export * from './useCreateProblemMutation';

--- a/src/pages/Class/Problem/hooks/query/useCreateProblemMutation.ts
+++ b/src/pages/Class/Problem/hooks/query/useCreateProblemMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createProblem } from '../../api';
+
+export const useCreateProblemMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, FormData>
+) => {
+  return useMutation((payload) => createProblem(payload), {
+    ...options,
+  });
+};

--- a/src/pages/Class/Problem/hooks/query/useProblemQuery.ts
+++ b/src/pages/Class/Problem/hooks/query/useProblemQuery.ts
@@ -1,0 +1,23 @@
+import { UseQueryOptions, QueryKey } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getProblem } from '../../api';
+
+export const useProblemQuery = (
+  problemId: QueryKey,
+  options?: UseQueryOptions<Problem, AxiosError, Problem, QueryKey[]>
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_PROBLEM, problemId],
+    async ({ queryKey: [, problemId] }) => {
+      const { data } = await getProblem(String(problemId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/Problem/index.ts
+++ b/src/pages/Class/Problem/index.ts
@@ -1,0 +1,8 @@
+export * from './ProblemForm';
+
+export * from './AllProblemDetail';
+
+export * from './ProblemDescription';
+export * from './ProblemData';
+export * from './ProblemLeaderBoard';
+export * from './ProblemSubmission';

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -2,3 +2,4 @@ export * from './ClassList';
 export * from './ClassListEdit';
 export * from './Class';
 export * from './ClassProblemList';
+export * from './Problem';

--- a/src/types/problem.d.ts
+++ b/src/types/problem.d.ts
@@ -1,0 +1,23 @@
+type Problem = {
+  id: number;
+  class_id: number;
+  title: string;
+  description: string;
+  data_description: string;
+  evaluation: string;
+  created_user: string;
+  created_time: string;
+  is_deleted: boolean;
+  public: boolean;
+};
+
+type ProblemRequest = {
+  title: string;
+  class_id: number;
+  description: string;
+  data: 파일;
+  data_description: string;
+  evaluation: string;
+  public: boolean;
+  solution: 파일;
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to: #53 

## 구현 기능

- 전체 문제 상세 조회
- 문제 생성 폼


## 스크린샷

<!--해당 PR에 대한 이미지 -->

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217435013-614730a5-4459-40d1-8e6b-cd7599a210b2.png">

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217435178-a7c7855a-59c6-4b80-8c5d-7f3cbd13f6e5.png">



## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- 문제 생성은 전체 문제 생성 api만 있어서 해당 api와 연결. contest problem 생성 api가 생기면 교체 예정
- 문제 생성 > 문제 설명, 데이터 설명:  마크다운으로 교체 필요