### PR TITLE
feat: contest 사이드바 - contest 생성 / 편집

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
   ClassStudentManagement,
   AdminAllClasses,
   AdminAllProblems,
+  ClassEditContestList,
 } from '@/pages';
 import { MainHeader } from '@/components';
 import ResetPassword from './pages/User/ResetPassword';
@@ -38,6 +39,7 @@ export default function App() {
               <Route path={SUB_PATH.ALL_PROBLEMS} element={<ClassProblemList />} />
               <Route path={SUB_PATH.STUDENT_MANAGEMENT} element={<ClassStudentManagement />} />
               <Route path={SUB_PATH.CONTEST} element={<ClassContest />}>
+                <Route path={SUB_PATH.CONTEST_LIST_EDIT} element={<ClassEditContestList />} />
                 <Route path={SUB_PATH.CONTEST_DETAIL} element={<ClassContestProblemList />} />
               </Route>
             </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,21 @@ import { Routes, Route } from 'react-router-dom';
 
 import Home from './pages/Home';
 
-import { Login, Register, Faq, Admin, ClassList, Class, ClassProblemList } from '@/pages';
+import {
+  Login,
+  Register,
+  Faq,
+  Admin,
+  ClassList,
+  Class,
+  ClassProblemList,
+  ProblemDescription,
+  ProblemData,
+  ProblemLeaderBoard,
+  ProblemSubmission,
+  AllProblemDetail,
+  ProblemForm,
+} from '@/pages';
 import { MainHeader } from '@/components';
 import { AdminAllProblems } from './pages/Admin';
 import { PATH, SUB_PATH } from '@/constants';
@@ -20,8 +34,15 @@ export default function App() {
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
             <Route path={PATH.CLASS_LIST} element={<ClassList />} />
-            <Route path={PATH.CLASS_DETAIL} element={<Class />}>
+            <Route path={`${PATH.CLASS_DETAIL}/*`} element={<Class />}>
               <Route path={SUB_PATH.ALL_PROBLEMS} element={<ClassProblemList />} />
+              <Route path={SUB_PATH.PROBLEM} element={<AllProblemDetail />}>
+                <Route path={SUB_PATH.DESCRIPTION} element={<ProblemDescription />} />
+                <Route path={SUB_PATH.DATA} element={<ProblemData />} />
+                <Route path={SUB_PATH.LEADERBOARD} element={<ProblemLeaderBoard />} />
+                <Route path={SUB_PATH.SUBMISSON} element={<ProblemSubmission />} />
+              </Route>
+              <Route path={SUB_PATH.PROBLEM_CREATE} element={<ProblemForm />}></Route>
             </Route>
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />
             <Route path={PATH.ANNOUNCEMENT_LIST} element={<div>AnnouncementList</div>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,11 @@ import {
   Class,
   ClassProblemList,
   ClassContest,
-  ClassStudentManagement,
   ClassContestProblemList,
   AdminAnnouncementList,
   ClassStudentManagement,
   AdminAllClasses,
-  AdminAllProblems
+  AdminAllProblems,
 } from '@/pages';
 import { MainHeader } from '@/components';
 import ResetPassword from './pages/User/ResetPassword';

--- a/src/components/atom/Switch.tsx
+++ b/src/components/atom/Switch.tsx
@@ -10,6 +10,7 @@ export function Switch({ enabled, onClick, className }: SwitchProps<'button'>) {
       <label className="inline-flex relative items-center cursor-pointer">
         <input type="checkbox" className="sr-only peer" checked={enabled} readOnly />
         <button
+          type="button"
           onClick={onClick}
           className="w-11 h-6 bg-gray-200 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-300"
         ></button>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from './localStorage';
 export * from './paths';
 export * from './queryKeys';
 export * from './privilege';
+export * from './metrics';

--- a/src/constants/metrics.ts
+++ b/src/constants/metrics.ts
@@ -1,0 +1,10 @@
+export const METRICS = [
+  'MSE',
+  'CategorizationAccuracy',
+  'RMSE',
+  'MAE',
+  'F1-score',
+  'Log-loss',
+  'RMSLE',
+  'mAP',
+];

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -19,6 +19,8 @@ export const SUB_PATH = {
   LEADERBOARD: 'leaderboard',
   SUBMISSON: 'submission',
 
+  PROBLEM: ':problemId',
+  PROBLEM_CREATE: 'create',
   ALL_PROBLEMS: 'all-problems',
   ALL_CLASSES: 'all-classes',
   ANNOUNCEMENTS: 'announcements',
@@ -60,6 +62,6 @@ export const PAGE: { [key: string]: string } = {
   CLASS_ALL_PROBLEMS: '전체 문제 목록',
   CLASS_STUDENT_MANAGEMENT: '수강생 및 TA 관리',
   CLASS_CONTEST: '과제 및 시험',
-  
+
   ALL_PROBLEMS: '전체 문제 목록',
 };

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -30,6 +30,7 @@ export const SUB_PATH = {
   STUDENT_MANAGEMENT: 'student-management',
   CONTEST: 'contest',
   CONTEST_DETAIL: ':contestId',
+  CONTEST_LIST_EDIT: 'edit',
 };
 
 export const PATH: { [key: string]: string } = {

--- a/src/pages/Class/ClassContest.tsx
+++ b/src/pages/Class/ClassContest.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react';
 import { useParams, Outlet } from 'react-router-dom';
 
-import { Header } from '@/components';
+import { Header, Heading, Button } from '@/components';
 
+import { ContestFormModal } from './components';
 import { useClassContestListQuery } from './hooks';
 
 export function ClassContest() {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
   const { classId } = useParams() as { classId: string };
   const {
     data: { results },
@@ -13,7 +17,13 @@ export function ClassContest() {
 
   return (
     <div className="grid gap-4 grid-cols-none sm:grid-cols-6">
-      <Header className="py-2 row-span-1 sm:col-span-1">
+      <Header className="row-span-1 sm:col-span-1">
+        <div className="flex items-center mb-4">
+          <Heading as="h5">목록</Heading>
+          <Button onClick={() => setShowCreateModal(true)}>추가</Button>
+          <Button>편집</Button>
+          <ContestFormModal showModal={showCreateModal} setShowModal={setShowCreateModal} />
+        </div>
         <Header.MenuList
           menuList={menuList}
           className="flex items-center justify-center gap-4 flex-col"

--- a/src/pages/Class/ClassContest.tsx
+++ b/src/pages/Class/ClassContest.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import { useParams, Outlet } from 'react-router-dom';
+import { useParams, Outlet, useNavigate } from 'react-router-dom';
 
 import { Header, Heading, Button } from '@/components';
+import { SUB_PATH } from '@/constants';
 
 import { ContestFormModal } from './components';
 import { useClassContestListQuery } from './hooks';
 
 export function ClassContest() {
+  const navigate = useNavigate();
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const { classId } = useParams() as { classId: string };
@@ -21,7 +23,7 @@ export function ClassContest() {
         <div className="flex items-center mb-4">
           <Heading as="h5">목록</Heading>
           <Button onClick={() => setShowCreateModal(true)}>추가</Button>
-          <Button>편집</Button>
+          <Button onClick={() => navigate(`${SUB_PATH.CONTEST_LIST_EDIT}`)}>편집</Button>
           <ContestFormModal showModal={showCreateModal} setShowModal={setShowCreateModal} />
         </div>
         <Header.MenuList

--- a/src/pages/Class/ClassEditContestList.tsx
+++ b/src/pages/Class/ClassEditContestList.tsx
@@ -1,0 +1,41 @@
+import { useParams } from 'react-router-dom';
+
+import { Button, Heading, Switch, Table } from '@/components';
+
+import { useClassContestListQuery, useEditContestVisibleMutation } from './hooks';
+
+export function ClassEditContestList() {
+  const { classId } = useParams() as { classId: string };
+
+  const column = [
+    { Header: '제목', accessor: 'name' },
+    { Header: '공개', accessor: 'visible' },
+    { Header: '편집', accessor: 'edit' },
+    { Header: '삭제', accessor: 'delete' },
+  ];
+
+  const { mutate: editContestVisible } = useEditContestVisibleMutation();
+
+  const handleSwitchButtonClick = (id: number) => {
+    editContestVisible({ classId, contestId: String(id) });
+  };
+
+  const {
+    data: { results },
+  } = useClassContestListQuery(classId);
+  const data = results.map((contest) => ({
+    ...contest,
+    visible: (
+      <Switch enabled={contest.visible} onClick={() => handleSwitchButtonClick(contest.id)} />
+    ),
+    edit: <Button>편집</Button>,
+    delete: <Button>삭제</Button>,
+  }));
+
+  return (
+    <>
+      <Heading as="h4">과제 및 시험 목록 편집</Heading>
+      <Table column={column} data={data} />
+    </>
+  );
+}

--- a/src/pages/Class/ClassEditContestList.tsx
+++ b/src/pages/Class/ClassEditContestList.tsx
@@ -1,11 +1,21 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Button, Heading, Switch, Table } from '@/components';
 
-import { useClassContestListQuery, useEditContestVisibleMutation } from './hooks';
+import {
+  useClassContestListQuery,
+  useDeleteContestMutation,
+  useEditContestVisibleMutation,
+} from './hooks';
+
+import { ContestEditModal } from './components';
 
 export function ClassEditContestList() {
   const { classId } = useParams() as { classId: string };
+
+  const [showModal, setShowModal] = useState(false);
+  const [editingContestId, setEditingContestId] = useState('');
 
   const column = [
     { Header: '제목', accessor: 'name' },
@@ -15,27 +25,46 @@ export function ClassEditContestList() {
   ];
 
   const { mutate: editContestVisible } = useEditContestVisibleMutation();
-
   const handleSwitchButtonClick = (id: number) => {
-    editContestVisible({ classId, contestId: String(id) });
+    editContestVisible({ classId, contestId: `${id}` });
+  };
+
+  const { mutate: deleteContest } = useDeleteContestMutation();
+  const handleDeleteButtonClick = (id: number, name: string) => {
+    const isConfirmed = confirm(`${name}을 삭제하시겠습니까?`);
+    if (isConfirmed) deleteContest({ classId, contestId: `${id}` });
+  };
+
+  const handleEditButtonClick = (id: number) => {
+    setEditingContestId(`${id}`);
+    setShowModal(true);
   };
 
   const {
     data: { results },
   } = useClassContestListQuery(classId);
-  const data = results.map((contest) => ({
-    ...contest,
-    visible: (
-      <Switch enabled={contest.visible} onClick={() => handleSwitchButtonClick(contest.id)} />
-    ),
-    edit: <Button>편집</Button>,
-    delete: <Button>삭제</Button>,
-  }));
+  const data = results.map((contest) => {
+    const { id, name, visible } = contest;
+    return {
+      ...contest,
+      visible: <Switch enabled={visible} onClick={() => handleSwitchButtonClick(id)} />,
+      edit: <Button onClick={() => handleEditButtonClick(id)}>편집</Button>,
+      delete: <Button onClick={() => handleDeleteButtonClick(id, name)}>삭제</Button>,
+    };
+  });
+
+  const modalData = results.find(({ id }) => editingContestId === `${id}`);
 
   return (
     <>
       <Heading as="h4">과제 및 시험 목록 편집</Heading>
       <Table column={column} data={data} />
+      <ContestEditModal
+        contestId={editingContestId}
+        data={modalData}
+        showModal={showModal}
+        setShowModal={setShowModal}
+      />
     </>
   );
 }

--- a/src/pages/Class/Problem/AllProblemDetail.tsx
+++ b/src/pages/Class/Problem/AllProblemDetail.tsx
@@ -1,0 +1,19 @@
+import { useParams } from 'react-router-dom';
+
+import { SUB_PATH } from '@/constants';
+
+import { Problem } from './components';
+import { useProblemQuery } from './hooks';
+
+export function AllProblemDetail() {
+  const { problemId } = useParams() as { id: string; problemId: string };
+
+  const { data } = useProblemQuery(problemId);
+
+  const menuList = [
+    { name: '문제 설명', to: SUB_PATH.DESCRIPTION },
+    { name: '데이터', to: SUB_PATH.DATA },
+  ];
+
+  return <Problem menuList={menuList} data={data} />;
+}

--- a/src/pages/Class/Problem/ProblemData.tsx
+++ b/src/pages/Class/Problem/ProblemData.tsx
@@ -1,0 +1,6 @@
+import { useOutletContext } from 'react-router-dom';
+
+export function ProblemData() {
+  const { data_description: dataDescription } = useOutletContext<{ data_description: string }>();
+  return <>{dataDescription}</>;
+}

--- a/src/pages/Class/Problem/ProblemDescription.tsx
+++ b/src/pages/Class/Problem/ProblemDescription.tsx
@@ -1,0 +1,6 @@
+import { useOutletContext } from 'react-router-dom';
+
+export function ProblemDescription() {
+  const { description } = useOutletContext<{ description: string }>();
+  return <>{description}</>;
+}

--- a/src/pages/Class/Problem/ProblemForm.tsx
+++ b/src/pages/Class/Problem/ProblemForm.tsx
@@ -1,0 +1,62 @@
+import { useParams } from 'react-router-dom';
+
+import { Button, Heading, Label, Input, Select, Switch } from '@/components';
+import { METRICS } from '@/constants';
+
+import { useCreateProblemMutation } from './hooks';
+
+export function ProblemForm() {
+  const options = METRICS.map((metric) => ({ value: metric }));
+  const { id: classId } = useParams() as { id: string };
+  const { mutate: createProblem } = useCreateProblemMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const formValue = Object.values(e.target)
+      .filter(({ nodeName }) => nodeName === 'INPUT' || nodeName === 'SELECT')
+      .map(({ value, files }) => (files ? files[0] : value));
+
+    const payloadKey = [
+      'title',
+      'description',
+      'evaluation',
+      'public',
+      'data_description',
+      'data',
+      'solution',
+    ];
+
+    const formData = new FormData();
+    formData.append('class_id', classId);
+    payloadKey.forEach((key, index) => formData.append(key, formValue[index]));
+
+    createProblem(formData);
+  };
+
+  return (
+    <form onSubmit={handleFormSubmit} className="flex flex-col gap-2">
+      <Heading as="h3">문제 생성</Heading>
+      <Input required placeholder="문제 이름을 입력하세요." />
+      <div>
+        <Heading as="h4">문제 설명</Heading>
+        {/* FIXME: 마크다운 */}
+        <Input required placeholder="문제 설명을 입력하세요." />
+        <Label>평가 지표</Label>
+        <Select required options={options} />
+        <Label>전체 공개</Label>
+        <Switch enabled={true} />
+      </div>
+      <div>
+        <Heading as="h4">데이터</Heading>
+        {/* FIXME: 마크다운 */}
+        <Input placeholder="데이터 설명을 입력하세요." />
+        <Label>데이터 파일</Label>
+        <Input type="file" accept=".zip" required />
+        <Label>정답 파일</Label>
+        <Input type="file" accept=".csv" required />
+      </div>
+      <Button>저장</Button>
+    </form>
+  );
+}

--- a/src/pages/Class/Problem/ProblemLeaderBoard.tsx
+++ b/src/pages/Class/Problem/ProblemLeaderBoard.tsx
@@ -1,0 +1,17 @@
+import { Table } from '@/components';
+
+export function ProblemLeaderBoard() {
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: '이름', accessor: 'name' },
+    { Header: '점수', accessor: 'score' },
+    { Header: '제출 날짜', accessor: 'time' },
+    { Header: '코드(.ipynb)', accessor: 'ipynbFile' },
+    { Header: '답안(.csv)', accessor: 'csvFile' },
+  ];
+
+  /** FIXME: 수업 상세 정보 */
+  const data = [{ id: 1 }];
+
+  return <Table column={column} data={data} />;
+}

--- a/src/pages/Class/Problem/ProblemSubmission.tsx
+++ b/src/pages/Class/Problem/ProblemSubmission.tsx
@@ -1,0 +1,34 @@
+import { Button, Heading, Table, Input } from '@/components';
+
+export function ProblemSubmission() {
+  const column = [
+    { Header: '#', accessor: 'id' },
+    { Header: 'csv 파일', accessor: 'csvFile' },
+    { Header: 'ipynb 파일', accessor: 'ipynbFile' },
+    { Header: '점수', accessor: 'score' },
+    { Header: 'status', accessor: 'status' },
+    { Header: '제출 날짜', accessor: 'submissionDate' },
+  ];
+  /** FIXME: 수업 상세 정보 */
+  const data = [{ id: 1 }];
+
+  return (
+    <>
+      <form className="flex flex-col gap-2 mb-10">
+        <Heading as="h4">csv 파일 제출</Heading>
+        <p>하나의 csv 파일만 업로드 가능합니다</p>
+        <Input type="file" accept=".csv" />
+
+        <Heading as="h4">ipynb 파일 제출</Heading>
+        <p>하나의 ipynb 파일만 업로드 가능합니다</p>
+        <Input type="file" accept=".ipynb" />
+
+        <Button className="inline-block">파일 제출</Button>
+      </form>
+
+      <Heading as="h4">제출 내역</Heading>
+      <p>선택한 제출 내역이 리더보드에 표시됩니다.</p>
+      <Table column={column} data={data} />
+    </>
+  );
+}

--- a/src/pages/Class/Problem/api/index.ts
+++ b/src/pages/Class/Problem/api/index.ts
@@ -1,0 +1,13 @@
+import { api, fileApi } from '@/api';
+
+const API_URL = `/problems`;
+
+const getProblem = (problemId: string) => {
+  return api.get(`${API_URL}/${problemId}`);
+};
+
+const createProblem = (payload: FormData) => {
+  return fileApi.post(`${API_URL}/`, payload);
+};
+
+export { getProblem, createProblem };

--- a/src/pages/Class/Problem/components/Problem.tsx
+++ b/src/pages/Class/Problem/components/Problem.tsx
@@ -1,0 +1,26 @@
+import { Outlet } from 'react-router-dom';
+
+import { Header, Heading } from '@/components';
+
+type ProblemProps = {
+  menuList: { name: string; to: string }[];
+  data: Problem;
+};
+
+export function Problem({ menuList, data }: ProblemProps) {
+  return (
+    <>
+      <Heading as="h3" className="pageTitle">
+        {data.title}
+      </Heading>
+      <div className="grid gap-4 grid-cols-none sm:grid-cols-6">
+        <Header className="py-2 row-span-1 sm:col-span-1">
+          <Header.MenuList menuList={menuList} />
+        </Header>
+        <section className="sm:col-span-5">
+          <Outlet context={data} />
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Class/Problem/components/index.ts
+++ b/src/pages/Class/Problem/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Problem';

--- a/src/pages/Class/Problem/hooks/index.ts
+++ b/src/pages/Class/Problem/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/src/pages/Class/Problem/hooks/query/index.ts
+++ b/src/pages/Class/Problem/hooks/query/index.ts
@@ -1,0 +1,2 @@
+export * from './useProblemQuery';
+export * from './useCreateProblemMutation';

--- a/src/pages/Class/Problem/hooks/query/useCreateProblemMutation.ts
+++ b/src/pages/Class/Problem/hooks/query/useCreateProblemMutation.ts
@@ -1,0 +1,12 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createProblem } from '../../api';
+
+export const useCreateProblemMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, FormData>
+) => {
+  return useMutation((payload) => createProblem(payload), {
+    ...options,
+  });
+};

--- a/src/pages/Class/Problem/hooks/query/useProblemQuery.ts
+++ b/src/pages/Class/Problem/hooks/query/useProblemQuery.ts
@@ -1,0 +1,23 @@
+import { UseQueryOptions, QueryKey } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getProblem } from '../../api';
+
+export const useProblemQuery = (
+  problemId: QueryKey,
+  options?: UseQueryOptions<Problem, AxiosError, Problem, QueryKey[]>
+) => {
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_PROBLEM, problemId],
+    async ({ queryKey: [, problemId] }) => {
+      const { data } = await getProblem(String(problemId));
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/Problem/index.ts
+++ b/src/pages/Class/Problem/index.ts
@@ -1,0 +1,8 @@
+export * from './ProblemForm';
+
+export * from './AllProblemDetail';
+
+export * from './ProblemDescription';
+export * from './ProblemData';
+export * from './ProblemLeaderBoard';
+export * from './ProblemSubmission';

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -86,6 +86,22 @@ const editContestVisible = (classId: string, contestId: string) => {
   return api.patch(`${API_URL}/${classId}/contests/${contestId}/check/`);
 };
 
+const deleteContest = (classId: string, contestId: string) => {
+  return api.delete(`${API_URL}/${classId}/contests/${contestId}/`);
+};
+
+const editContest = ({
+  classId,
+  contestId,
+  payload,
+}: {
+  classId: string;
+  contestId: string;
+  payload: ContestRequest;
+}) => {
+  return api.patch(`${API_URL}/${classId}/contests/${contestId}/`, payload);
+};
+
 export {
   getClassList,
   editClassList,
@@ -102,4 +118,6 @@ export {
   getContestProblemList,
   createContest,
   editContestVisible,
+  deleteContest,
+  editContest,
 };

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -28,4 +28,21 @@ const getProblemList = ({ keyword }: { keyword: string }) => {
   return api.get(`/problems?keyword=${keyword}`);
 };
 
-export { getClassList, editClassList, getClass, editClass, deleteClass, getProblemList };
+const editProblemPublic = (problemId: string) => {
+  return api.post(`/problems/${problemId}/check/`);
+};
+
+const deleteProblem = (problemId: string) => {
+  return api.delete(`/problems/${problemId}`);
+};
+
+export {
+  getClassList,
+  editClassList,
+  getClass,
+  editClass,
+  deleteClass,
+  getProblemList,
+  editProblemPublic,
+  deleteProblem,
+};

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -82,6 +82,10 @@ const createContest = ({ classId, payload }: { classId: string; payload: Contest
   return api.post(`${API_URL}/${classId}/contests/`, payload);
 };
 
+const editContestVisible = (classId: string, contestId: string) => {
+  return api.patch(`${API_URL}/${classId}/contests/${contestId}/check/`);
+};
+
 export {
   getClassList,
   editClassList,
@@ -97,4 +101,5 @@ export {
   getContestList,
   getContestProblemList,
   createContest,
+  editContestVisible,
 };

--- a/src/pages/Class/api/index.ts
+++ b/src/pages/Class/api/index.ts
@@ -4,6 +4,8 @@ import { api } from '@/api';
 
 const API_URL = `/class`;
 
+/** ClassList */
+
 const getClassList = (): Promise<AxiosResponse<ClassListResponse>> => {
   return api.get(`/users${API_URL}/`);
 };
@@ -11,6 +13,8 @@ const getClassList = (): Promise<AxiosResponse<ClassListResponse>> => {
 const editClassList = (payload: ClassListIdRequest) => {
   return api.patch(`/users${API_URL}/`, payload);
 };
+
+/** Class */
 
 const getClass = (classId: string): Promise<AxiosResponse<ClassResponse>> => {
   return api.get(`${API_URL}/${classId}/`);
@@ -28,9 +32,13 @@ const deleteClass = (classId: string) => {
   return api.delete(`${API_URL}/${classId}`);
 };
 
+/** 전체 문제 목록 */
+
 const getProblemList = ({ keyword }: { keyword: string }) => {
   return api.get(`/problems?keyword=${keyword}`);
 };
+
+/** 수강생 및 TA 관리 */
 
 const getClassStudentList = (classId: string) => {
   return api.get(`${API_URL}/${classId}/std/`);
@@ -60,12 +68,18 @@ const createClassTaList = ({
   return api.post(`${API_URL}/${classId}/ta/`, payload);
 };
 
+/** 과제 및 시험 */
+
 const getContestList = (classId: string) => {
   return api.get(`${API_URL}/${classId}/contests`);
 };
 
 const getContestProblemList = (classId: string, contestId: string) => {
   return api.get(`${API_URL}/${classId}/contests/${contestId}`);
+};
+
+const createContest = ({ classId, payload }: { classId: string; payload: ContestRequest }) => {
+  return api.post(`${API_URL}/${classId}/contests/`, payload);
 };
 
 export {
@@ -76,10 +90,11 @@ export {
   editClass,
   deleteClass,
   getProblemList,
-  getContestList,
   getClassStudentList,
   getClassTaList,
   createClassStudentList,
   createClassTaList,
+  getContestList,
   getContestProblemList,
+  createContest,
 };

--- a/src/pages/Class/components/ContestEditModal.tsx
+++ b/src/pages/Class/components/ContestEditModal.tsx
@@ -1,0 +1,60 @@
+import { useParams } from 'react-router-dom';
+
+import { StateAndAction } from '@/types/state';
+import { Modal, Button } from '@/components';
+
+import { useContestModalBody, useEditContestMutation } from '../hooks';
+
+type ContestEditmModal<T extends React.ElementType> = Component<T> &
+  StateAndAction<boolean, 'showModal'> & {
+    contestId: string;
+    data?: ContestRequest & { id: number; class_id: number };
+  };
+
+export function ContestEditModal({
+  contestId,
+  data,
+  showModal,
+  setShowModal,
+}: ContestEditmModal<'div'>) {
+  const { classId } = useParams() as { classId: string };
+
+  const { renderBody, isExam, visible } = useContestModalBody(data);
+
+  const { mutate: editContest } = useEditContestMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => {
+    e.preventDefault();
+
+    const [name, startTime, endTime] = Object.values(e.target).map(({ value }) => value);
+
+    editContest({
+      classId,
+      contestId,
+      payload: {
+        name,
+        start_time: startTime,
+        end_time: endTime,
+        is_exam: isExam,
+        visible,
+      },
+    });
+
+    setShowModal(false);
+  };
+
+  return (
+    <Modal open={showModal}>
+      <Modal.Header>과제 및 시험 목록 편집</Modal.Header>
+      <form onSubmit={handleFormSubmit}>
+        <Modal.Body className="w-[300px] flex flex-col gap-2">{renderBody()}</Modal.Body>
+        <Modal.Footer className="gap-2">
+          <Button color="success">저장하기</Button>
+          <Button color="error" type="button" onClick={() => setShowModal(false)}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/src/pages/Class/components/ContestFormModal.tsx
+++ b/src/pages/Class/components/ContestFormModal.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
-import { Button, Label, Modal, Input, Switch } from '@/components';
+import { Button, Modal } from '@/components';
 import { StateAndAction } from '@/types/state';
 
-import { useCreateContestMutation } from '../hooks';
-import { useParams } from 'react-router-dom';
+import { useContestModalBody, useCreateContestMutation } from '../hooks';
 
 type ContestFormModal<T extends React.ElementType> = Component<T> &
   StateAndAction<boolean, 'showModal'>;
@@ -12,8 +11,7 @@ type ContestFormModal<T extends React.ElementType> = Component<T> &
 export function ContestFormModal({ showModal, setShowModal }: ContestFormModal<'div'>) {
   const { classId } = useParams() as { classId: string };
 
-  const [isExam, setIsExam] = useState(false);
-  const [visible, setVisible] = useState(false);
+  const { renderBody, isExam, visible } = useContestModalBody();
 
   const { mutate: createContest } = useCreateContestMutation();
 
@@ -32,9 +30,7 @@ export function ContestFormModal({ showModal, setShowModal }: ContestFormModal<'
         visible,
       },
     });
-  };
 
-  const handleCloseButtonClick = () => {
     setShowModal(false);
   };
 
@@ -42,23 +38,10 @@ export function ContestFormModal({ showModal, setShowModal }: ContestFormModal<'
     <Modal open={showModal}>
       <Modal.Header>과제 및 시험 목록 생성</Modal.Header>
       <form onSubmit={handleFormSubmit}>
-        <Modal.Body className="w-[300px] flex flex-col gap-2">
-          <Label>과제 및 시험 목록</Label>
-          <Input required placeholder="과제 및 시험명" />
-          <Label>시작 시간</Label>
-          <Input type="datetime-local" required placeholder="시작 시간" />
-          <Label>종료 시간</Label>
-          <Input type="datetime-local" required placeholder="종료 시간" />
-          <div className="flex items-center gap-2">
-            <Label>시험 모드</Label>
-            <Switch enabled={isExam} onClick={() => setIsExam(!isExam)} />
-            <Label>공개</Label>
-            <Switch enabled={visible} onClick={() => setVisible(!visible)} />
-          </div>
-        </Modal.Body>
+        <Modal.Body className="w-[300px] flex flex-col gap-2">{renderBody()}</Modal.Body>
         <Modal.Footer className="gap-2">
           <Button color="success">저장하기</Button>
-          <Button color="error" type="button" onClick={handleCloseButtonClick}>
+          <Button color="error" type="button" onClick={() => setShowModal(false)}>
             닫기
           </Button>
         </Modal.Footer>

--- a/src/pages/Class/components/ContestFormModal.tsx
+++ b/src/pages/Class/components/ContestFormModal.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+
+import { Button, Label, Modal, Input, Switch } from '@/components';
+import { StateAndAction } from '@/types/state';
+
+import { useCreateContestMutation } from '../hooks';
+import { useParams } from 'react-router-dom';
+
+type ContestFormModal<T extends React.ElementType> = Component<T> &
+  StateAndAction<boolean, 'showModal'>;
+
+export function ContestFormModal({ showModal, setShowModal }: ContestFormModal<'div'>) {
+  const { classId } = useParams() as { classId: string };
+
+  const [isExam, setIsExam] = useState(false);
+  const [visible, setVisible] = useState(false);
+
+  const { mutate: createContest } = useCreateContestMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => {
+    e.preventDefault();
+
+    const [name, startTime, endTime] = Object.values(e.target).map(({ value }) => value);
+
+    createContest({
+      classId,
+      payload: {
+        name,
+        start_time: startTime,
+        end_time: endTime,
+        is_exam: isExam,
+        visible,
+      },
+    });
+  };
+
+  const handleCloseButtonClick = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <Modal open={showModal}>
+      <Modal.Header>과제 및 시험 목록 생성</Modal.Header>
+      <form onSubmit={handleFormSubmit}>
+        <Modal.Body className="w-[300px] flex flex-col gap-2">
+          <Label>과제 및 시험 목록</Label>
+          <Input required placeholder="과제 및 시험명" />
+          <Label>시작 시간</Label>
+          <Input type="datetime-local" required placeholder="시작 시간" />
+          <Label>종료 시간</Label>
+          <Input type="datetime-local" required placeholder="종료 시간" />
+          <div className="flex items-center gap-2">
+            <Label>시험 모드</Label>
+            <Switch enabled={isExam} onClick={() => setIsExam(!isExam)} />
+            <Label>공개</Label>
+            <Switch enabled={visible} onClick={() => setVisible(!visible)} />
+          </div>
+        </Modal.Body>
+        <Modal.Footer className="gap-2">
+          <Button color="success">저장하기</Button>
+          <Button color="error" type="button" onClick={handleCloseButtonClick}>
+            닫기
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/src/pages/Class/components/index.ts
+++ b/src/pages/Class/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ClassEditModal';
 export * from './ClassStudentForm';
 export * from './ClassFormModal';
+export * from './ContestFormModal';

--- a/src/pages/Class/components/index.ts
+++ b/src/pages/Class/components/index.ts
@@ -2,3 +2,4 @@ export * from './ClassEditModal';
 export * from './ClassStudentForm';
 export * from './ClassFormModal';
 export * from './ContestFormModal';
+export * from './ContestEditModal';

--- a/src/pages/Class/hooks/index.ts
+++ b/src/pages/Class/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useModalBody';
 export * from './useClassProblemListTable';
 export * from './useStudentForm';
 export * from './useContestProblemListTable';
+export * from './useContestModalBody';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -17,3 +17,4 @@ export * from './useClassContestListQuery';
 export * from './useClassContestProblemQuery';
 
 export * from './useCreateContestMutation';
+export * from './useEditContestVisibleMutation';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -15,3 +15,5 @@ export * from './useClassTaListMutation';
 
 export * from './useClassContestListQuery';
 export * from './useClassContestProblemQuery';
+
+export * from './useCreateContestMutation';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -4,3 +4,7 @@ export * from './useEditClassListMutation';
 export * from './useClassQuery';
 export * from './useEditClassMutation';
 export * from './useDeleteClassMutation';
+
+export * from './useProblemListQuery';
+export * from './useEditProblemPublicMutation';
+export * from './useDeleteProblemMutation';

--- a/src/pages/Class/hooks/query/index.ts
+++ b/src/pages/Class/hooks/query/index.ts
@@ -18,3 +18,5 @@ export * from './useClassContestProblemQuery';
 
 export * from './useCreateContestMutation';
 export * from './useEditContestVisibleMutation';
+export * from './useDeleteContestMutation';
+export * from './useEditContestMutation';

--- a/src/pages/Class/hooks/query/useCreateContestMutation.ts
+++ b/src/pages/Class/hooks/query/useCreateContestMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createContest } from '../../api';
+
+type useCreateContestProps = { classId: string; payload: ContestRequest };
+
+export const useCreateContestMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useCreateContestProps>
+) => {
+  return useMutation(({ classId, payload }) => createContest({ classId, payload }), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useCreateContestMutation.ts
+++ b/src/pages/Class/hooks/query/useCreateContestMutation.ts
@@ -1,5 +1,7 @@
-import { useMutation, UseMutationOptions } from 'react-query';
 import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+import { QUERY_KEYS } from '@/constants/queryKeys';
 
 import { createContest } from '../../api';
 
@@ -8,7 +10,11 @@ type useCreateContestProps = { classId: string; payload: ContestRequest };
 export const useCreateContestMutation = (
   options?: UseMutationOptions<AxiosResponse, AxiosError, useCreateContestProps>
 ) => {
+  const queryClient = useQueryClient();
   return useMutation(({ classId, payload }) => createContest({ classId, payload }), {
     ...options,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(QUERY_KEYS.CLASS_CONTEST);
+    },
   });
 };

--- a/src/pages/Class/hooks/query/useDeleteContestMutation.ts
+++ b/src/pages/Class/hooks/query/useDeleteContestMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { deleteContest } from '../../api';
+
+type useDeleteContestVisibleProps = {
+  classId: string;
+  contestId: string;
+};
+
+export const useDeleteContestMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useDeleteContestVisibleProps>
+) => {
+  return useMutation(({ classId, contestId }) => deleteContest(classId, contestId), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useDeleteProblemMutation.ts
+++ b/src/pages/Class/hooks/query/useDeleteProblemMutation.ts
@@ -1,0 +1,12 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation, UseMutationOptions } from 'react-query';
+
+import { deleteProblem } from '../../api';
+
+export const useDeleteProblemMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, string>
+) => {
+  return useMutation((problemId) => deleteProblem(problemId), {
+    ...options,
+  });
+};

--- a/src/pages/Class/hooks/query/useEditContestMutation.ts
+++ b/src/pages/Class/hooks/query/useEditContestMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { editContest } from '../../api';
+
+type useEditContestProps = { classId: string; contestId: string; payload: ContestRequest };
+
+export const useEditContestMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useEditContestProps>
+) => {
+  return useMutation(
+    ({ classId, contestId, payload }) => editContest({ classId, contestId, payload }),
+    {
+      ...options,
+      onSuccess: () => {
+        alert('편집 완료');
+      },
+    }
+  );
+};

--- a/src/pages/Class/hooks/query/useEditContestVisibleMutation.ts
+++ b/src/pages/Class/hooks/query/useEditContestVisibleMutation.ts
@@ -1,0 +1,23 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useQueryClient, useMutation, UseMutationOptions } from 'react-query';
+
+import { QUERY_KEYS } from '@/constants';
+import { editContestVisible } from '../../api';
+
+type useEditContestVisibleProps = {
+  classId: string;
+  contestId: string;
+};
+
+export const useEditContestVisibleMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, useEditContestVisibleProps>
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation(({ classId, contestId }) => editContestVisible(classId, contestId), {
+    ...options,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(QUERY_KEYS.CLASS_CONTEST);
+    },
+  });
+};

--- a/src/pages/Class/hooks/query/useEditProblemPublicMutation.ts
+++ b/src/pages/Class/hooks/query/useEditProblemPublicMutation.ts
@@ -1,0 +1,18 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+
+import { QUERY_KEYS } from '@/constants';
+
+import { editProblemPublic } from '../../api';
+
+export const useEditProblemPublicMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, string>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation((problemId) => editProblemPublic(problemId), {
+    ...options,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(QUERY_KEYS.CLASS_PROBLEM);
+    },
+  });
+};

--- a/src/pages/Class/hooks/useClassProblemListTable.tsx
+++ b/src/pages/Class/hooks/useClassProblemListTable.tsx
@@ -3,7 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Switch } from '@/components';
 import { formatTime } from '@/utils/time';
 
-import { useProblemListQuery } from './query';
+import {
+  useEditProblemPublicMutation,
+  useDeleteProblemMutation,
+  useProblemListQuery,
+} from './query';
 
 export const useClassProblemListTable = (keyword: string) => {
   const navigate = useNavigate();
@@ -17,18 +21,35 @@ export const useClassProblemListTable = (keyword: string) => {
     { Header: '삭제', accessor: 'delete' },
   ];
 
+  const { mutate: editProblemPublic } = useEditProblemPublicMutation();
+
+  const handleEditButtonClick = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
+    e.stopPropagation();
+
+    editProblemPublic(`${id}`);
+  };
+
+  const { mutate: deleteProblem } = useDeleteProblemMutation();
+
+  const handleDeleteButtonClick = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
+    e.stopPropagation();
+
+    const isConfirmed = confirm(`삭제하시겠습니까?`);
+    if (isConfirmed) deleteProblem(`${id}`);
+  };
+
   const {
     data: { results },
   } = useProblemListQuery({ keyword });
   const data = results
     .sort(({ created_time: prev }, { created_time: next }) => +new Date(next) - +new Date(prev))
     .map((problem) => {
-      const { created_time: createdTime, public: isPublic } = problem;
+      const { id, created_time: createdTime, public: isPublic } = problem;
       return {
         ...problem,
         created_time: formatTime(createdTime),
-        public: <Switch enabled={isPublic} />,
-        delete: <Button>삭제</Button>,
+        public: <Switch enabled={isPublic} onClick={(e) => handleEditButtonClick(e, id)} />,
+        delete: <Button onClick={(e) => handleDeleteButtonClick(e, id)}>삭제</Button>,
       };
     });
 

--- a/src/pages/Class/hooks/useContestModalBody.tsx
+++ b/src/pages/Class/hooks/useContestModalBody.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+import { Label, Switch, Input } from '@/components';
+
+export const useContestModalBody = (data?: ContestRequest) => {
+  const {
+    name,
+    start_time: startTime,
+    end_time: endTime,
+    is_exam: _isExam,
+    visible: _visible,
+  } = data ?? {};
+
+  const [isExam, setIsExam] = useState(!!_isExam);
+  const [visible, setVisible] = useState(!!_visible);
+
+  useEffect(() => {
+    setIsExam(!!_isExam);
+    setVisible(!!_visible);
+  }, [_isExam, _visible]);
+
+  const contents = [
+    {
+      id: 'name',
+      label: '과제 및 시험명',
+      element: <Input required defaultValue={name} placeholder="과제 및 시험명" />,
+    },
+    {
+      id: 'startTime',
+      label: '시작 시간',
+      element: (
+        <Input type="datetime-local" required defaultValue={startTime} placeholder="시작 시간" />
+      ),
+    },
+    {
+      id: 'endTime',
+      label: '종료 시간',
+      element: (
+        <Input type="datetime-local" required defaultValue={endTime} placeholder="종료 시간" />
+      ),
+    },
+    {
+      id: 'isExam',
+      label: '시험 모드',
+      element: <Switch enabled={isExam} onClick={() => setIsExam(!isExam)} />,
+    },
+    {
+      id: 'visible',
+      label: '공개',
+      element: <Switch enabled={visible} onClick={() => setVisible(!visible)} />,
+    },
+  ];
+
+  const renderBody = () => {
+    return contents.map(({ id, label, element }) => (
+      <div key={id}>
+        <Label htmlFor={id}>{label}</Label>
+        {element}
+      </div>
+    ));
+  };
+
+  return {
+    renderBody,
+    isExam,
+    visible,
+  };
+};

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -5,3 +5,4 @@ export * from './ClassProblemList';
 export * from './ClassContest';
 export * from './ClassContestProblemList';
 export * from './ClassStudentManagement';
+export * from './ClassEditContestList';

--- a/src/pages/Class/index.ts
+++ b/src/pages/Class/index.ts
@@ -2,3 +2,4 @@ export * from './ClassList';
 export * from './ClassListEdit';
 export * from './Class';
 export * from './ClassProblemList';
+export * from './Problem';

--- a/src/types/class.d.ts
+++ b/src/types/class.d.ts
@@ -71,3 +71,11 @@ type ContestProblemList = {
 }[];
 
 type ContestProblemListResponse = ApiResponse<ContestProblemList>;
+
+type ContestRequest = {
+  name: string;
+  start_time: string;
+  end_time: string;
+  is_exam: boolean;
+  visible: boolean;
+};

--- a/src/types/problem.d.ts
+++ b/src/types/problem.d.ts
@@ -1,0 +1,23 @@
+type Problem = {
+  id: number;
+  class_id: number;
+  title: string;
+  description: string;
+  data_description: string;
+  evaluation: string;
+  created_user: string;
+  created_time: string;
+  is_deleted: boolean;
+  public: boolean;
+};
+
+type ProblemRequest = {
+  title: string;
+  class_id: number;
+  description: string;
+  data: 파일;
+  data_description: string;
+  evaluation: string;
+  public: boolean;
+  solution: 파일;
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Related to: #50 

## 구현 기능

- 과제 및 시험 contest 생성
- 과제 및 시험 contest 편집
  - 공개 수정
  - 편집
  - 삭제

## 변경 로직

- Switch 컴포넌트 버튼 타입 변경: submit → button
  - 기본 type이 submit이라 form 요소 내부에 존재하는 경우, 누를 때마다 submit 이벤트 발생
  - ex ) 스크린샷에서 시험모드, 공개 버튼을 누를 때마다 제출되어서 타입 변경

## 스크린샷

<!--해당 PR에 대한 이미지 -->

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217518842-fcf2942b-5d87-4159-8b8c-9dd146526abb.png">

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217568736-c47e2fe6-43c6-4f27-8de4-f511b3d2c953.png">

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217569726-1b73d235-148f-41bc-8786-c11f40bfd40a.png">



## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- ~~현재 백엔드 오류로 제대로 생성 안됨~~
  - ~~백엔드 오류 문의한 상태여서 확인 후 머지하겠습니다~~
  → 해결되었습니다
- 브랜치 안바꾸고 작업해서 커밋 양이 많아졌습니다....스미마셍..🥹
