### PR TITLE
feat: 수업 문제 상세 조회 - 리더보드 / 제출

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   ClassContestProblemList,
   ClassStudentManagement,
   AllProblemDetail,
+  ContestProblemDetail,
   ProblemDescription,
   ProblemData,
   ProblemLeaderBoard,
@@ -45,6 +46,13 @@ export default function App() {
               <Route path={SUB_PATH.STUDENT_MANAGEMENT} element={<ClassStudentManagement />} />
               <Route path={SUB_PATH.CONTEST} element={<ClassContest />}>
                 <Route path={SUB_PATH.CONTEST_DETAIL} element={<ClassContestProblemList />} />
+                <Route path={SUB_PATH.CONTEST_PROBLEM} element={<ContestProblemDetail />}>
+                  <Route path={SUB_PATH.DESCRIPTION} element={<ProblemDescription />} />
+                  <Route path={SUB_PATH.DATA} element={<ProblemData />} />
+                  <Route path={SUB_PATH.LEADERBOARD} element={<ProblemLeaderBoard />} />
+                  <Route path={SUB_PATH.SUBMISSON} element={<ProblemSubmission />} />
+                </Route>
+                <Route path={SUB_PATH.PROBLEM_CREATE} element={<ProblemForm />}></Route>
               </Route>
               <Route path={SUB_PATH.PROBLEM} element={<AllProblemDetail />}>
                 <Route path={SUB_PATH.DESCRIPTION} element={<ProblemDescription />} />
@@ -52,7 +60,6 @@ export default function App() {
                 <Route path={SUB_PATH.LEADERBOARD} element={<ProblemLeaderBoard />} />
                 <Route path={SUB_PATH.SUBMISSON} element={<ProblemSubmission />} />
               </Route>
-              <Route path={SUB_PATH.PROBLEM_CREATE} element={<ProblemForm />}></Route>
             </Route>
             <Route path={PATH.CLASS_LIST} element={<ClassList />}></Route>
             <Route path={PATH.BOARD_LIST} element={<div>BoardList</div>} />

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -22,7 +22,7 @@ export const SUB_PATH = {
   SUBMISSON: 'submission',
 
   PROBLEM: ':problemId',
-  PROBLEM_CREATE: 'create',
+  PROBLEM_CREATE: ':contestId/create',
   ALL_PROBLEMS: 'all-problems',
   ALL_CLASSES: 'all-classes',
   ANNOUNCEMENTS: 'announcements',
@@ -32,6 +32,7 @@ export const SUB_PATH = {
   STUDENT_MANAGEMENT: 'student-management',
   CONTEST: 'contest',
   CONTEST_DETAIL: ':contestId',
+  CONTEST_PROBLEM: ':contestId/:contestProblemId',
 };
 
 export const PATH: { [key: string]: string } = {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -10,4 +10,5 @@ export const QUERY_KEYS = {
   CLASS_STUDENT: 'class-student',
   CLASS_TA: 'class-ta',
   CLASS_CONTEST: 'class-contest',
+  CLASS_CONTEST_PROBLEM: 'class-contest-problem',
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -11,4 +11,5 @@ export const QUERY_KEYS = {
   CLASS_TA: 'class-ta',
   CLASS_CONTEST: 'class-contest',
   CLASS_CONTEST_PROBLEM: 'class-contest-problem',
+  CLASS_CONTEST_PROBLEM_SUBMISSION: 'class-contest-problem-submission',
 };

--- a/src/pages/Class/ClassContestProblemList.tsx
+++ b/src/pages/Class/ClassContestProblemList.tsx
@@ -1,9 +1,10 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button, Heading, Table } from '@/components';
 import { useContestProblemListTable, useClassContestListQuery } from './hooks';
 
 export function ClassContestProblemList() {
+  const navigate = useNavigate();
   const { classId, contestId } = useParams() as { classId: string; contestId: string };
   const {
     data: { results },
@@ -12,11 +13,15 @@ export function ClassContestProblemList() {
 
   const tableProps = useContestProblemListTable(classId, contestId);
 
+  const handleCreateButtonClick = () => {
+    navigate('create');
+  };
+
   return (
     <>
       <header className="flex justify-between items-center">
         <Heading as="h3">{title}</Heading>
-        <Button>문제 생성</Button>
+        <Button onClick={handleCreateButtonClick}>문제 생성</Button>
       </header>
       <Table {...tableProps} />
     </>

--- a/src/pages/Class/Problem/ContestProblemDetail.tsx
+++ b/src/pages/Class/Problem/ContestProblemDetail.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router-dom';
+
+import { SUB_PATH } from '@/constants';
+
+import { Problem } from './components';
+import { useContestProblemQuery } from './hooks';
+
+export function ContestProblemDetail() {
+  const { classId, contestId, contestProblemId } = useParams() as {
+    classId: string;
+    contestId: string;
+    contestProblemId: string;
+  };
+
+  const { data } = useContestProblemQuery({ classId, contestId, contestProblemId });
+
+  const menuList = [
+    { name: '문제 설명', to: SUB_PATH.DESCRIPTION },
+    { name: '데이터', to: SUB_PATH.DATA },
+    { name: '리더보드', to: SUB_PATH.LEADERBOARD },
+    { name: '제출', to: SUB_PATH.SUBMISSON },
+  ];
+
+  return <Problem menuList={menuList} data={data} />;
+}

--- a/src/pages/Class/Problem/ProblemLeaderBoard.tsx
+++ b/src/pages/Class/Problem/ProblemLeaderBoard.tsx
@@ -1,17 +1,33 @@
+import { useParams } from 'react-router-dom';
+
 import { Table } from '@/components';
+import { formatTime } from '@/utils/time';
+
+import { useContestProblemSubmissionQuery } from './hooks';
 
 export function ProblemLeaderBoard() {
+  const { classId, contestId, contestProblemId } = useParams() as {
+    classId: string;
+    contestId: string;
+    contestProblemId: string;
+  };
+  /** TODO: 파일 다운로드 부분 추가 */
   const column = [
     { Header: '#', accessor: 'id' },
-    { Header: '이름', accessor: 'name' },
+    { Header: '이름', accessor: 'username' },
     { Header: '점수', accessor: 'score' },
-    { Header: '제출 날짜', accessor: 'time' },
-    { Header: '코드(.ipynb)', accessor: 'ipynbFile' },
-    { Header: '답안(.csv)', accessor: 'csvFile' },
+    { Header: '제출 날짜', accessor: 'submissionDate' },
   ];
 
-  /** FIXME: 수업 상세 정보 */
-  const data = [{ id: 1 }];
+  /** FIXME: 새로운 api로 교체해야함 */
+  const {
+    data: { results },
+  } = useContestProblemSubmissionQuery({ classId, contestId, contestProblemId });
+
+  const data = results
+    .sort(({ score: prev }, { score: next }) => next - prev)
+    .sort(({ created_time: prev }, { created_time: next }) => +new Date(prev) - +new Date(next))
+    .map((submission) => ({ ...submission, submissionDate: formatTime(submission.created_time) }));
 
   return <Table column={column} data={data} />;
 }

--- a/src/pages/Class/Problem/ProblemSubmission.tsx
+++ b/src/pages/Class/Problem/ProblemSubmission.tsx
@@ -1,34 +1,45 @@
-import { Button, Heading, Table, Input } from '@/components';
+import { useParams } from 'react-router-dom';
+
+import {
+  useCreateContestProblemSubmissionCheckMutation,
+  useCreateContestProblemSubmissionMutation,
+} from './hooks';
+
+import { FileSubmissionForm, LeaderboardSubmissionForm } from './components';
 
 export function ProblemSubmission() {
-  const column = [
-    { Header: '#', accessor: 'id' },
-    { Header: 'csv 파일', accessor: 'csvFile' },
-    { Header: 'ipynb 파일', accessor: 'ipynbFile' },
-    { Header: '점수', accessor: 'score' },
-    { Header: 'status', accessor: 'status' },
-    { Header: '제출 날짜', accessor: 'submissionDate' },
-  ];
-  /** FIXME: 수업 상세 정보 */
-  const data = [{ id: 1 }];
+  const { classId, contestId, contestProblemId } = useParams() as {
+    classId: string;
+    contestId: string;
+    contestProblemId: string;
+  };
+
+  const { mutate: createSubmission } = useCreateContestProblemSubmissionMutation();
+  const { mutate: createSubmissionCheck } = useCreateContestProblemSubmissionCheckMutation();
+
+  const handleFileSumbit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const [csv, ipynb] = Object.values(e.target).map(({ files }) => files && files[0]);
+
+    const formData = new FormData();
+    formData.append('csv', csv);
+    formData.append('ipynb', ipynb);
+
+    createSubmission({ classId, contestId, contestProblemId, payload: formData });
+  };
+
+  const handleCheckSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const { id } = Object.values(e.target).find(({ checked }) => checked);
+    createSubmissionCheck({ classId, contestId, contestProblemId, payload: { id } });
+  };
 
   return (
     <>
-      <form className="flex flex-col gap-2 mb-10">
-        <Heading as="h4">csv 파일 제출</Heading>
-        <p>하나의 csv 파일만 업로드 가능합니다</p>
-        <Input type="file" accept=".csv" />
-
-        <Heading as="h4">ipynb 파일 제출</Heading>
-        <p>하나의 ipynb 파일만 업로드 가능합니다</p>
-        <Input type="file" accept=".ipynb" />
-
-        <Button className="inline-block">파일 제출</Button>
-      </form>
-
-      <Heading as="h4">제출 내역</Heading>
-      <p>선택한 제출 내역이 리더보드에 표시됩니다.</p>
-      <Table column={column} data={data} />
+      <FileSubmissionForm onSubmit={handleFileSumbit} />
+      <LeaderboardSubmissionForm onSubmit={handleCheckSubmit} />
     </>
   );
 }

--- a/src/pages/Class/Problem/api/index.ts
+++ b/src/pages/Class/Problem/api/index.ts
@@ -10,4 +10,8 @@ const createProblem = (payload: FormData) => {
   return fileApi.post(`${API_URL}/`, payload);
 };
 
-export { getProblem, createProblem };
+const getContestProblem = ({ classId, contestId, contestProblemId }: ContestProblemRequest) => {
+  return api.get(`/class/${classId}/contests/${contestId}/${contestProblemId}`);
+};
+
+export { getProblem, createProblem, getContestProblem };

--- a/src/pages/Class/Problem/api/index.ts
+++ b/src/pages/Class/Problem/api/index.ts
@@ -14,4 +14,40 @@ const getContestProblem = ({ classId, contestId, contestProblemId }: ContestProb
   return api.get(`/class/${classId}/contests/${contestId}/${contestProblemId}`);
 };
 
-export { getProblem, createProblem, getContestProblem };
+/** FIXME: 페이지네이션, username */
+const getContestProblemSubmission = ({
+  classId,
+  contestId,
+  contestProblemId,
+}: ContestProblemRequest) => {
+  return api.get(`/class/${classId}/contests/${contestId}/${contestProblemId}/submissions`);
+};
+
+const createContestProblemSubmission = ({
+  classId,
+  contestId,
+  contestProblemId,
+  payload,
+}: ContestProblemRequest & { payload: FormData }) => {
+  return fileApi.post(
+    `/class/${classId}/contests/${contestId}/${contestProblemId}/submission/`,
+    payload
+  );
+};
+
+const createContestProblemSumbissionCheck = ({
+  classId,
+  contestId,
+  contestProblemId,
+}: ContestProblemRequest) => {
+  return api.patch(`/class/${classId}/contests/${contestId}/${contestProblemId}/check/`);
+};
+
+export {
+  getProblem,
+  createProblem,
+  getContestProblem,
+  getContestProblemSubmission,
+  createContestProblemSubmission,
+  createContestProblemSumbissionCheck,
+};

--- a/src/pages/Class/Problem/components/FileSubmissionForm.tsx
+++ b/src/pages/Class/Problem/components/FileSubmissionForm.tsx
@@ -1,0 +1,19 @@
+import { Heading, Input, Button } from '@/components';
+
+type FileSubmissionFormProps<T extends React.ElementType> = Component<T>;
+
+export function FileSubmissionForm({ ...props }: FileSubmissionFormProps<'form'>) {
+  return (
+    <form className="flex flex-col gap-2 mb-10" {...props}>
+      <Heading as="h4">csv 파일 제출</Heading>
+      <p>하나의 csv 파일만 업로드 가능합니다</p>
+      <Input type="file" accept=".csv" />
+
+      <Heading as="h4">ipynb 파일 제출</Heading>
+      <p>하나의 ipynb 파일만 업로드 가능합니다</p>
+      <Input type="file" accept=".ipynb" />
+
+      <Button className="inline-block">파일 제출</Button>
+    </form>
+  );
+}

--- a/src/pages/Class/Problem/components/LeaderboardSubmissionForm.tsx
+++ b/src/pages/Class/Problem/components/LeaderboardSubmissionForm.tsx
@@ -1,0 +1,47 @@
+import { useParams } from 'react-router-dom';
+
+import { Heading, Table, Button } from '@/components';
+import { formatTime } from '@/utils/time';
+
+import { useContestProblemSubmissionQuery } from '../hooks';
+
+type FileSubmissionFormProps<T extends React.ElementType> = Component<T>;
+
+export function LeaderboardSubmissionForm({ ...props }: FileSubmissionFormProps<'form'>) {
+  const { classId, contestId, contestProblemId } = useParams() as {
+    classId: string;
+    contestId: string;
+    contestProblemId: string;
+  };
+
+  const column = [
+    { Header: 'check', accessor: 'check' },
+    { Header: 'csv 파일', accessor: 'csvFile' },
+    { Header: 'ipynb 파일', accessor: 'ipynbFile' },
+    { Header: '점수', accessor: 'score' },
+    { Header: 'status', accessor: 'status' },
+    { Header: '제출 날짜', accessor: 'submissionDate' },
+  ];
+
+  const {
+    data: { results },
+  } = useContestProblemSubmissionQuery({ classId, contestId, contestProblemId });
+
+  const data = results
+    .sort(({ score: prev }, { score: next }) => next - prev)
+    .sort(({ created_time: prev }, { created_time: next }) => +new Date(prev) - +new Date(next))
+    .map((submission) => ({
+      ...submission,
+      check: <input type="checkbox" id={submission.id} />,
+      submissionDate: formatTime(submission.created_time),
+    }));
+
+  return (
+    <form className="flex flex-col gap-2 mb-10" {...props}>
+      <Heading as="h4">제출 내역</Heading>
+      <p>선택한 제출 내역이 리더보드에 표시됩니다.</p>
+      <Table column={column} data={data} />
+      <Button>제출</Button>
+    </form>
+  );
+}

--- a/src/pages/Class/Problem/components/index.ts
+++ b/src/pages/Class/Problem/components/index.ts
@@ -1,1 +1,3 @@
 export * from './Problem';
+export * from './FileSubmissionForm';
+export * from './LeaderboardSubmissionForm';

--- a/src/pages/Class/Problem/hooks/query/index.ts
+++ b/src/pages/Class/Problem/hooks/query/index.ts
@@ -1,2 +1,6 @@
 export * from './useProblemQuery';
 export * from './useCreateProblemMutation';
+export * from './useContestProblemQuery';
+export * from './useContestProblemSubmissionQuery';
+export * from './useCreateContestProblemSubmissionMutation';
+export * from './useCreateContestProblemSubmissionCheckMutation';

--- a/src/pages/Class/Problem/hooks/query/useContestProblemQuery.ts
+++ b/src/pages/Class/Problem/hooks/query/useContestProblemQuery.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios';
+import { UseQueryOptions } from 'react-query';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getContestProblem } from '../../api';
+
+export const useContestProblemQuery = (
+  params: ContestProblemRequest,
+  options?: UseQueryOptions<Problem, AxiosError, Problem, string[]>
+) => {
+  const { classId, contestId, contestProblemId } = params;
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_CONTEST_PROBLEM, classId, contestId, contestProblemId],
+    async () => {
+      const { data } = await getContestProblem(params);
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/Problem/hooks/query/useContestProblemSubmissionQuery.ts
+++ b/src/pages/Class/Problem/hooks/query/useContestProblemSubmissionQuery.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from 'axios';
+import { UseQueryOptions } from 'react-query';
+
+import { useSuspenseQuery } from '@/hooks/useSuspenseQuery';
+import { QUERY_KEYS } from '@/constants';
+
+import { getContestProblemSubmission } from '../../api';
+
+export const useContestProblemSubmissionQuery = (
+  params: ContestProblemRequest,
+  options?: UseQueryOptions<
+    ContestProblemSubmissionResponse,
+    AxiosError,
+    ContestProblemSubmissionResponse,
+    string[]
+  >
+) => {
+  const { classId, contestId, contestProblemId } = params;
+  return useSuspenseQuery(
+    [QUERY_KEYS.CLASS_CONTEST_PROBLEM_SUBMISSION, classId, contestId, contestProblemId],
+    async () => {
+      const { data } = await getContestProblemSubmission(params);
+      return data;
+    },
+    {
+      ...options,
+    }
+  );
+};

--- a/src/pages/Class/Problem/hooks/query/useCreateContestProblemSubmissionCheckMutation.ts
+++ b/src/pages/Class/Problem/hooks/query/useCreateContestProblemSubmissionCheckMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createContestProblemSumbissionCheck } from '../../api';
+
+type createContestProblemSumbissionCheck = {
+  classId: string;
+  contestId: string;
+  contestProblemId: string;
+  payload: { id: string };
+};
+
+export const useCreateContestProblemSubmissionCheckMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, createContestProblemSumbissionCheck>
+) => {
+  return useMutation((payload) => createContestProblemSumbissionCheck(payload), {
+    ...options,
+    onSuccess: () => {
+      alert('성공');
+    },
+  });
+};

--- a/src/pages/Class/Problem/hooks/query/useCreateContestProblemSubmissionMutation.ts
+++ b/src/pages/Class/Problem/hooks/query/useCreateContestProblemSubmissionMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, UseMutationOptions } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+
+import { createContestProblemSubmission } from '../../api';
+
+type createContestProblemSubmissionRequest = {
+  classId: string;
+  contestId: string;
+  contestProblemId: string;
+  payload: FormData;
+};
+
+export const useCreateContestProblemSubmissionMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, createContestProblemSubmissionRequest>
+) => {
+  return useMutation((payload) => createContestProblemSubmission(payload), {
+    ...options,
+    onSuccess: () => {
+      alert('성공');
+    },
+  });
+};

--- a/src/pages/Class/Problem/index.ts
+++ b/src/pages/Class/Problem/index.ts
@@ -1,6 +1,7 @@
 export * from './ProblemForm';
 
 export * from './AllProblemDetail';
+export * from './ContestProblemDetail';
 
 export * from './ProblemDescription';
 export * from './ProblemData';

--- a/src/types/problem.d.ts
+++ b/src/types/problem.d.ts
@@ -21,3 +21,18 @@ type ProblemRequest = {
   public: boolean;
   solution: 파일;
 };
+
+type ContestProblem = {
+  id: number;
+  contest_id: number;
+  problem_id: number;
+  title: string;
+  description: string;
+  data_description: string;
+  start_time: string;
+  end_time: string;
+  evaluation: string;
+  problem_data: string;
+};
+
+type ContestProblemRequest = { classId: string; contestId: string; contestProblemId: string };

--- a/src/types/problem.d.ts
+++ b/src/types/problem.d.ts
@@ -15,11 +15,11 @@ type ProblemRequest = {
   title: string;
   class_id: number;
   description: string;
-  data: 파일;
+  data: Blob;
   data_description: string;
   evaluation: string;
   public: boolean;
-  solution: 파일;
+  solution: Blob;
 };
 
 type ContestProblem = {
@@ -36,3 +36,19 @@ type ContestProblem = {
 };
 
 type ContestProblemRequest = { classId: string; contestId: string; contestProblemId: string };
+
+type ContestProblemSubmission = {
+  id: nubmer;
+  username: string;
+  score: number;
+  status: number;
+  on_leaderboard: boolean;
+  created_time: string;
+}[];
+
+type ContestProblemSubmissionResponse = ApiResponse<ContestProblemSubmission>;
+
+type ContestProblemSubmissionRequest = {
+  csv: Blob;
+  ipynb: Blob;
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

- Resolve: #55 

## 구현 기능

- 리더보드 조회
- 파일 제출
- 제출 내역 조회
- 리더보드 제출

## 스크린샷

<!--해당 PR에 대한 이미지 -->

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217721677-226e405f-a634-4c0d-8ec1-b429ae92ba13.png">

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/80238096/217721721-fe4caf6b-57b3-43d3-bf97-b7406de18c30.png">



## 참고 사항

<!-- 궁금한 점, 논의할 점 등 -->

- 현재 리더보드 조회 API가 전체 사용자의 전체 제출 내역을 조회(리더보드에 제출하지 않은 것도 조회됨)하고 있어서 백엔드에 문의하였습니다. 
  - 이 부분은 추후에 수정 필요
- 파일 관련 부분은 API가 변경되지 않아서 미구현
- 제출 내역 > status 부분 숫자 의미를 파악하기 어려워 백엔드에 문의한 상태