### PR TITLE
feat: 관리자페이지 페이지네이션 추가

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -5,24 +5,21 @@ import './Pagination.css';
 export type Props = {
   currentPage: number;
   lastPage: number;
-  maxLength: number;
+  maxLength?: number;
   setCurrentPage: (page: number) => void;
 };
 
 export default function Pagination({
   currentPage,
   lastPage,
-  maxLength,
+  maxLength = 8,
   setCurrentPage,
 }: Props) {
   const pageNums = getPaginationItems(currentPage, lastPage, maxLength);
 
   return (
     <nav className="pagination" aria-label="Pagination">
-      <PageLink
-        disabled={currentPage === 1}
-        onClick={() => setCurrentPage(currentPage - 1)}
-      >
+      <PageLink disabled={currentPage === 1} onClick={() => setCurrentPage(currentPage - 1)}>
         Previous
       </PageLink>
       {pageNums.map((pageNum, idx) => (
@@ -35,10 +32,7 @@ export default function Pagination({
           {!isNaN(pageNum) ? pageNum : '...'}
         </PageLink>
       ))}
-      <PageLink
-        disabled={currentPage === lastPage}
-        onClick={() => setCurrentPage(currentPage + 1)}
-      >
+      <PageLink disabled={currentPage === lastPage} onClick={() => setCurrentPage(currentPage + 1)}>
         Next
       </PageLink>
     </nav>

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,8 +1,4 @@
-export function getPaginationItems(
-  currentPage: number,
-  lastPage: number,
-  maxLength: number
-) {
+export function getPaginationItems(currentPage: number, lastPage: number, maxLength: number) {
   const res: Array<number> = [];
 
   // handle lastPage less than maxLength
@@ -17,13 +13,10 @@ export function getPaginationItems(
     const firstPage = 1;
     const confirmedPagesCount = 3;
     const deductedMaxLength = maxLength - confirmedPagesCount;
-    const sideLength = deductedMaxLength / 2;
+    const sideLength = Math.ceil(deductedMaxLength / 2);
 
     // handle ellipsis in the middle
-    if (
-      currentPage - firstPage < sideLength ||
-      lastPage - currentPage < sideLength
-    ) {
+    if (currentPage - firstPage < sideLength || lastPage - currentPage < sideLength) {
       for (let j = 1; j <= sideLength + firstPage; j++) {
         res.push(j);
       }
@@ -45,11 +38,7 @@ export function getPaginationItems(
       res.push(1);
       res.push(NaN);
 
-      for (
-        let l = currentPage - deductedSideLength;
-        l <= currentPage + deductedSideLength;
-        l++
-      ) {
+      for (let l = currentPage - deductedSideLength; l <= currentPage + deductedSideLength; l++) {
         res.push(l);
       }
 

--- a/src/pages/Admin/Announcement/AdminAnnouncementList.tsx
+++ b/src/pages/Admin/Announcement/AdminAnnouncementList.tsx
@@ -1,13 +1,16 @@
 import { Button, Heading, Input, Table } from '@/components';
+import Pagination from '@/components/Pagination';
 import { PAGE, PATH } from '@/constants/paths';
 import { useSearch } from '@/hooks/useSearch';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAdminAnnouncementsTable } from './hooks';
 
 export function AdminAnnouncementList() {
   const navigate = useNavigate();
   const { keyword, onChange } = useSearch();
-  const { column, data } = useAdminAnnouncementsTable(keyword);
+  const [currentPage, setCurrentPage] = useState(1);
+  const { column, data, page } = useAdminAnnouncementsTable(keyword, currentPage);
 
   return (
     <>
@@ -28,6 +31,7 @@ export function AdminAnnouncementList() {
         </div>
       </div>
       <Table column={column} data={data} />
+      <Pagination setCurrentPage={setCurrentPage} {...page} />
     </>
   );
 }

--- a/src/pages/Admin/Announcement/api/index.ts
+++ b/src/pages/Admin/Announcement/api/index.ts
@@ -5,9 +5,10 @@ import { api } from '@/api';
 const API_URL = `/admin/announcements`;
 
 const getAnnouncements = (
-  keyword: string
+  keyword: string,
+  currentPage: number
 ): Promise<AxiosResponse<AdminAnnouncementListResponse>> => {
-  return api.get(`${API_URL}?keyword=${keyword}`);
+  return api.get(`${API_URL}?keyword=${keyword}&page=${currentPage}`);
 };
 
 const deleteAnnouncement = (announcementId: string) => {

--- a/src/pages/Admin/Announcement/hooks/query/useAdminAnnouncementListQuery.ts
+++ b/src/pages/Admin/Announcement/hooks/query/useAdminAnnouncementListQuery.ts
@@ -7,17 +7,18 @@ import { getAnnouncements } from '../../api';
 
 export const useAdminAnnouncementListQuery = (
   keyword: string,
+  currentPage: number,
   options?: UseQueryOptions<
     AdminAnnouncementListResponse,
     AxiosError,
     AdminAnnouncementListResponse,
-    [string, string]
+    [string, string, number]
   >
 ) => {
   return useSuspenseQuery(
-    [QUERY_KEYS.ADMIN_ANNOUNCEMENT_LIST, keyword],
-    async ({ queryKey: [, keyword] }) => {
-      const { data } = await getAnnouncements(keyword);
+    [QUERY_KEYS.ADMIN_ANNOUNCEMENT_LIST, keyword, currentPage],
+    async ({ queryKey: [, keyword, currentPage] }) => {
+      const { data } = await getAnnouncements(keyword, currentPage);
       return data;
     },
     {

--- a/src/pages/Admin/Announcement/hooks/useAdminAnnouncementsTable.tsx
+++ b/src/pages/Admin/Announcement/hooks/useAdminAnnouncementsTable.tsx
@@ -10,7 +10,7 @@ import {
 import { formatTime } from '@/utils/time';
 import { Switch } from '@/components/atom/Switch';
 
-export const useAdminAnnouncementsTable = (keyword: string) => {
+export const useAdminAnnouncementsTable = (keyword: string, currentPage: number) => {
   const navigate = useNavigate();
   const { mutate: deleteAnnouncement } = useDeleteAnnouncementMutation();
   const { mutate: editAnnouncementSwitch } = useEditAnnouncementSwitchMutation();
@@ -56,56 +56,54 @@ export const useAdminAnnouncementsTable = (keyword: string) => {
   ];
 
   const {
-    data: { results },
-  } = useAdminAnnouncementListQuery(keyword);
+    data: { results, current_page, last_page },
+  } = useAdminAnnouncementListQuery(keyword, currentPage);
 
-  const data = results
-    .sort(({ id: prev }, { id: next }) => next - prev)
-    .map((_announcement) => {
-      const { id, title, visible, important } = _announcement;
-      const created_time = formatTime(_announcement.created_time);
-      const last_modified = formatTime(_announcement.last_modified);
+  const data = results.map((_announcement) => {
+    const { id, title, visible, important } = _announcement;
+    const created_time = formatTime(_announcement.created_time);
+    const last_modified = formatTime(_announcement.last_modified);
 
-      return {
-        ..._announcement,
-        created_time,
-        last_modified,
-        visible: (
-          <Switch
-            key={`${id}_visible_${String(visible)}`}
-            enabled={visible}
-            onClick={() => {
-              handleSwitchButtonClick({
-                id,
-                visible: !visible,
-              });
-            }}
-          />
-        ),
-        important: (
-          <Switch
-            key={`${id}_important_${String(important)}`}
-            enabled={important}
-            onClick={() => {
-              handleSwitchButtonClick({
-                id,
-                important: !important,
-              });
-            }}
-          />
-        ),
-        edit: (
-          <Button
-            onClick={() => {
-              navigate(`${PATH.ADMIN}/${PATH.ADMIN_ANNOUNCEMENT_LIST}/${id}/edit`);
-            }}
-          >
-            편집
-          </Button>
-        ),
-        delete: <Button onClick={(e) => handleDeleteButtonClick({ id, title, e })}>삭제</Button>,
-      };
-    });
+    return {
+      ..._announcement,
+      created_time,
+      last_modified,
+      visible: (
+        <Switch
+          key={`${id}_visible_${String(visible)}`}
+          enabled={visible}
+          onClick={() => {
+            handleSwitchButtonClick({
+              id,
+              visible: !visible,
+            });
+          }}
+        />
+      ),
+      important: (
+        <Switch
+          key={`${id}_important_${String(important)}`}
+          enabled={important}
+          onClick={() => {
+            handleSwitchButtonClick({
+              id,
+              important: !important,
+            });
+          }}
+        />
+      ),
+      edit: (
+        <Button
+          onClick={() => {
+            navigate(`${PATH.ADMIN}/${PATH.ADMIN_ANNOUNCEMENT_LIST}/${id}/edit`);
+          }}
+        >
+          편집
+        </Button>
+      ),
+      delete: <Button onClick={(e) => handleDeleteButtonClick({ id, title, e })}>삭제</Button>,
+    };
+  });
 
-  return { column, data };
+  return { column, data, page: { currentPage: current_page, lastPage: last_page } };
 };

--- a/src/pages/Admin/Class/AdminClassList.tsx
+++ b/src/pages/Admin/Class/AdminClassList.tsx
@@ -1,11 +1,14 @@
 import { Heading, Input, Table } from '@/components';
+import Pagination from '@/components/Pagination';
 import { PAGE } from '@/constants/paths';
 import { useSearch } from '@/hooks/useSearch';
+import { useState } from 'react';
 import { useAdminClassListTable } from './hooks';
 
 export function AdminClassList() {
   const { keyword, onChange } = useSearch();
-  const { column, data, handleRowClick } = useAdminClassListTable(keyword);
+  const [currentPage, setCurrentPage] = useState(1);
+  const { column, data, handleRowClick, page } = useAdminClassListTable(keyword, currentPage);
 
   return (
     <>
@@ -23,6 +26,7 @@ export function AdminClassList() {
         </div>
       </div>
       <Table column={column} data={data} onRowClick={handleRowClick} />
+      <Pagination setCurrentPage={setCurrentPage} {...page} />
     </>
   );
 }

--- a/src/pages/Admin/Class/api/index.ts
+++ b/src/pages/Admin/Class/api/index.ts
@@ -4,8 +4,11 @@ import { api } from '@/api';
 
 const API_URL = `/admin/class`;
 
-const getClasses = (keyword: string): Promise<AxiosResponse<AdminClassListResponse>> => {
-  return api.get(`${API_URL}?keyword=${keyword}`);
+const getClasses = (
+  keyword: string,
+  currentPage: number
+): Promise<AxiosResponse<AdminClassListResponse>> => {
+  return api.get(`${API_URL}?keyword=${keyword}&page=${currentPage}`);
 };
 
 export { getClasses };

--- a/src/pages/Admin/Class/hooks/query/useAdminClassListQuery.ts
+++ b/src/pages/Admin/Class/hooks/query/useAdminClassListQuery.ts
@@ -7,17 +7,18 @@ import { getClasses } from '../../api';
 
 export const useAdminClassListQuery = (
   keyword: string,
+  currentPage: number,
   options?: UseQueryOptions<
     AdminClassListResponse,
     AxiosError,
     AdminClassListResponse,
-    [string, string]
+    [string, string, number]
   >
 ) => {
   return useSuspenseQuery(
-    [QUERY_KEYS.ADMIN_CLASS_LIST, keyword],
-    async ({ queryKey: [, keyword] }) => {
-      const { data } = await getClasses(keyword);
+    [QUERY_KEYS.ADMIN_CLASS_LIST, keyword, currentPage],
+    async ({ queryKey: [, keyword, currentPage] }) => {
+      const { data } = await getClasses(keyword, currentPage);
       return data;
     },
     {

--- a/src/pages/Admin/Class/hooks/useAdminClassListTable.ts
+++ b/src/pages/Admin/Class/hooks/useAdminClassListTable.ts
@@ -3,7 +3,7 @@ import { PATH } from '@/constants/paths';
 import React from 'react';
 import { useAdminClassListQuery } from './query';
 
-export const useAdminClassListTable = (keyword: string) => {
+export const useAdminClassListTable = (keyword: string, currentPage: number) => {
   const navigate = useNavigate();
 
   const handleRowClick = (
@@ -22,10 +22,10 @@ export const useAdminClassListTable = (keyword: string) => {
   ];
 
   const {
-    data: { results },
-  } = useAdminClassListQuery(keyword);
+    data: { results, current_page, last_page },
+  } = useAdminClassListQuery(keyword, currentPage);
 
   const data = results;
 
-  return { column, data, handleRowClick };
+  return { column, data, handleRowClick, page: { currentPage: current_page, lastPage: last_page } };
 };

--- a/src/pages/Admin/Problem/AdminProblemList.tsx
+++ b/src/pages/Admin/Problem/AdminProblemList.tsx
@@ -2,10 +2,13 @@ import { Heading, Input, Table } from '@/components';
 import { PAGE } from '@/constants/paths';
 import { useAdminProblemListTable } from './hooks';
 import { useSearch } from '@/hooks/useSearch';
+import Pagination from '@/components/Pagination';
+import { useState } from 'react';
 
 export function AdminProblemList() {
   const { keyword, onChange } = useSearch();
-  const { column, data, handleRowClick } = useAdminProblemListTable(keyword);
+  const [currentPage, setCurrentPage] = useState(1);
+  const { column, data, handleRowClick, page } = useAdminProblemListTable(keyword, currentPage);
 
   return (
     <>
@@ -23,6 +26,7 @@ export function AdminProblemList() {
         </div>
       </div>
       <Table column={column} data={data} onRowClick={handleRowClick} />
+      <Pagination setCurrentPage={setCurrentPage} {...page} />
     </>
   );
 }

--- a/src/pages/Admin/Problem/api/index.ts
+++ b/src/pages/Admin/Problem/api/index.ts
@@ -4,8 +4,11 @@ import { api } from '@/api';
 
 const API_URL = `/admin/problems`;
 
-const getProblems = (keyword: string): Promise<AxiosResponse<AdminProblemListResponse>> => {
-  return api.get(`${API_URL}?keyword=${keyword}`);
+const getProblems = (
+  keyword: string,
+  currentPage: number
+): Promise<AxiosResponse<AdminProblemListResponse>> => {
+  return api.get(`${API_URL}?keyword=${keyword}&page=${currentPage}`);
 };
 
 const deleteProblem = (problemId: string) => {

--- a/src/pages/Admin/Problem/hooks/query/useAdminProblemListQuery.ts
+++ b/src/pages/Admin/Problem/hooks/query/useAdminProblemListQuery.ts
@@ -7,17 +7,18 @@ import { getProblems } from '../../api';
 
 export const useAdminProblemListQuery = (
   keyword: string,
+  currentPage: number,
   options?: UseQueryOptions<
     AdminProblemListResponse,
     AxiosError,
     AdminProblemListResponse,
-    [string, string]
+    [string, string, number]
   >
 ) => {
   return useSuspenseQuery(
-    [QUERY_KEYS.ADMIN_PROBLEM_LIST, keyword],
-    async ({ queryKey: [, keyword] }) => {
-      const { data } = await getProblems(keyword);
+    [QUERY_KEYS.ADMIN_PROBLEM_LIST, keyword, currentPage],
+    async ({ queryKey: [, keyword, currentPage] }) => {
+      const { data } = await getProblems(keyword, currentPage);
       return data;
     },
     {

--- a/src/pages/Admin/Problem/hooks/useAdminProblemListTable.tsx
+++ b/src/pages/Admin/Problem/hooks/useAdminProblemListTable.tsx
@@ -5,7 +5,7 @@ import { PATH } from '@/constants/paths';
 import React from 'react';
 import { useAdminProblemListQuery } from './query';
 
-export const useAdminProblemListTable = (keyword: string) => {
+export const useAdminProblemListTable = (keyword: string, currentPage: number) => {
   const navigate = useNavigate();
   const { mutate: deleteProblem } = useDeleteProblemMutation();
 
@@ -39,8 +39,8 @@ export const useAdminProblemListTable = (keyword: string) => {
   ];
 
   const {
-    data: { results },
-  } = useAdminProblemListQuery(keyword);
+    data: { results, current_page, last_page },
+  } = useAdminProblemListQuery(keyword, currentPage);
 
   const data = results.map((_problem) => {
     const { id, title } = _problem;
@@ -52,5 +52,5 @@ export const useAdminProblemListTable = (keyword: string) => {
     };
   });
 
-  return { column, data, handleRowClick };
+  return { column, data, handleRowClick, page: { currentPage: current_page, lastPage: last_page } };
 };

--- a/src/pages/Admin/User/AdminUserList.tsx
+++ b/src/pages/Admin/User/AdminUserList.tsx
@@ -1,12 +1,15 @@
 import { Heading, Input, Table } from '@/components';
+import Pagination from '@/components/Pagination';
 import { PAGE } from '@/constants';
 import { useSearch } from '@/hooks/useSearch';
+import { useState } from 'react';
 import { UserEditModal } from './components';
 import { useAdminUserTable } from './hooks';
 
 export function AdminUserList() {
   const { keyword, onChange } = useSearch();
-  const { column, data, modalProps } = useAdminUserTable(keyword);
+  const [currentPage, setCurrentPage] = useState(1);
+  const { column, data, modalProps, page } = useAdminUserTable(keyword, currentPage);
 
   return (
     <>
@@ -24,6 +27,7 @@ export function AdminUserList() {
         </div>
       </div>
       <Table column={column} data={data} />
+      <Pagination setCurrentPage={setCurrentPage} {...page} />
       {modalProps.showModal && <UserEditModal {...modalProps} />}
     </>
   );

--- a/src/pages/Admin/User/api/index.ts
+++ b/src/pages/Admin/User/api/index.ts
@@ -19,8 +19,11 @@ const deleteUser = (username: string) => {
   return api.delete(`${API_URL}/${username}`);
 };
 
-const getUsers = (keyword: string): Promise<AxiosResponse<AdminUserListResponse>> => {
-  return api.get(`${API_URL}?keyword=${keyword}`);
+const getUsers = (
+  keyword: string,
+  currentPage: number
+): Promise<AxiosResponse<AdminUserListResponse>> => {
+  return api.get(`${API_URL}?keyword=${keyword}&page=${currentPage}`);
 };
 
 export { getUser, editUserPrivilege, deleteUser, getUsers };

--- a/src/pages/Admin/User/hooks/query/useAdminUserListQuery.ts
+++ b/src/pages/Admin/User/hooks/query/useAdminUserListQuery.ts
@@ -7,17 +7,18 @@ import { getUsers } from '../../api';
 
 export const useAdminUserListQuery = (
   keyword: string,
+  currentPage: number,
   options?: UseQueryOptions<
     AdminUserListResponse,
     AxiosError,
     AdminUserListResponse,
-    [string, string]
+    [string, string, number]
   >
 ) => {
   return useSuspenseQuery(
-    [QUERY_KEYS.ADMIN_ALL_USERS, keyword],
-    async ({ queryKey: [, keyword] }) => {
-      const { data } = await getUsers(keyword);
+    [QUERY_KEYS.ADMIN_ALL_USERS, keyword, currentPage],
+    async ({ queryKey: [, keyword, currentPage] }) => {
+      const { data } = await getUsers(keyword, currentPage);
       return data;
     },
     {

--- a/src/pages/Admin/User/hooks/useAdminUserTable.tsx
+++ b/src/pages/Admin/User/hooks/useAdminUserTable.tsx
@@ -4,7 +4,7 @@ import { useAdminUserListQuery, useDeleteUserMutation } from '../hooks/query';
 import { formatTime } from '@/utils/time';
 import { PRIVILEGE } from '@/constants';
 
-export const useAdminUserTable = (keyword: string) => {
+export const useAdminUserTable = (keyword: string, currentPage: number) => {
   const { mutate: deleteFaq } = useDeleteUserMutation();
   const [showModal, setShowModal] = useState(false);
   const [username, setUserName] = useState('');
@@ -38,8 +38,8 @@ export const useAdminUserTable = (keyword: string) => {
   ];
 
   const {
-    data: { results },
-  } = useAdminUserListQuery(keyword);
+    data: { results, current_page, last_page },
+  } = useAdminUserListQuery(keyword, currentPage);
 
   const data = results.map((_user) => {
     const { username } = _user;
@@ -63,5 +63,6 @@ export const useAdminUserTable = (keyword: string) => {
       showModal,
       setShowModal,
     },
+    page: { currentPage: current_page, lastPage: last_page },
   };
 };

--- a/src/types/admin.d.ts
+++ b/src/types/admin.d.ts
@@ -17,8 +17,8 @@ type AdminClassList = {
 
 type AdminProblemListResponse = {
   count: number;
-  next: number | null;
-  previous: number | nulle;
+  current_page: number;
+  last_page: number;
   results: AdminProblemList[];
 };
 
@@ -33,8 +33,8 @@ type AdminAnnouncement = {
 
 type AdminAnnouncementListResponse = {
   count: number;
-  next: number | null;
-  previous: number | nulle;
+  current_page: number;
+  last_page: number;
   results: AdminAnnouncement[];
 };
 
@@ -45,8 +45,8 @@ type EditAnnouncementSwitchRequest = {
 
 type AdminClassListResponse = {
   count: number;
-  next: number | null;
-  previous: number | nulle;
+  current_page: number;
+  last_page: number;
   results: AdminClassList[];
 };
 
@@ -78,8 +78,8 @@ type AdminFaq = {
 
 type AdminFaqListResponse = {
   count: number;
-  next: number | null;
-  previous: number | nulle;
+  current_page: number;
+  last_page: number;
   results: AdminFaq[];
 };
 
@@ -111,7 +111,7 @@ type AdminUser = {
 
 type AdminUserListResponse = {
   count: number;
-  next: number | null;
-  previous: number | nulle;
+  current_page: number;
+  last_page: number;
   results: AdminUser[];
 };


### PR DESCRIPTION
## 구현 기능
* 관리자페이지의 페이지네이션 추가
  * 전체 수업 목록
  * 전체 문제 목록
  * 전체 공지사항 목록
  * 사용자 목록

## 변경 로직
* pagination 컴포넌트 props 중 `maxLength` 옵션으로 수정 + default 값로 설정

## 스크린샷
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/63294532/218265249-a7f61cc9-f07a-45d5-a304-9dd348aaf219.png">
