### PR TITLE
[feat] 비밀번호 찾기 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,5 +35,12 @@
       "version": "detect"
     }
   },
-  "rules": {}
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,8 @@ import {
 
 import { MainHeader } from '@/components';
 import ResetPassword from './pages/User/ResetPassword';
+import FindPassword from './pages/User/FindPassword';
+
 import { PATH, SUB_PATH } from '@/constants';
 
 export default function App() {
@@ -58,6 +60,7 @@ export default function App() {
             <Route path={PATH.LOGIN} element={<Login />} />
             <Route path={PATH.REGISTER} element={<Register />} />
             <Route path={PATH.RESET_PASSWORD} element={<ResetPassword />} />
+            <Route path={PATH.FIND_PASSWORD} element={<FindPassword />} />
             <Route path={PATH.COMPETITION_LIST} element={<div>CompetitionList</div>} />
 
             <Route path={`${PATH.CLASS_DETAIL}/*`} element={<Class />}>

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -4,6 +4,7 @@ export const BASE_PATH: { [key: string]: string } = {
   LOGIN: '/login',
   REGISTER: '/register',
   RESET_PASSWORD: '/reset-password',
+  FIND_PASSWORD: '/find-password',
 
   COMPETITION: '/competition',
   CLASS: '/class',

--- a/src/pages/User/FindPassword.tsx
+++ b/src/pages/User/FindPassword.tsx
@@ -1,0 +1,31 @@
+import { ErrorMessage, Heading } from '@/components';
+import { PAGE } from '@/constants';
+import { FindPasswordForm } from './components/FindPasswordForm';
+import { FINDPASSWORD_ERROR } from './constants';
+import { useFindPasswordForm } from './hooks';
+import { useFindPasswordMutation } from './hooks/query/useFindPasswordMutation';
+
+export default function FindPassword() {
+  const inputList = useFindPasswordForm();
+  const { mutate, isError } = useFindPasswordMutation();
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const [email] = Object.values(inputList).map(({ value }) => value);
+
+    mutate({
+      email: email,
+    });
+  };
+
+  return (
+    <div className="container max-w-md mx-auto">
+      <Heading className="text-2xl font-bold">비밀번호 변경</Heading>
+      <FindPasswordForm inputList={inputList} onSubmit={handleFormSubmit} />
+      {isError && (
+        <ErrorMessage className="mt-4">{FINDPASSWORD_ERROR.FIND_PASSWORD_FAILED}</ErrorMessage>
+      )}
+    </div>
+  );
+}

--- a/src/pages/User/FindPassword.tsx
+++ b/src/pages/User/FindPassword.tsx
@@ -21,7 +21,7 @@ export default function FindPassword() {
 
   return (
     <div className="container max-w-md mx-auto">
-      <Heading className="text-2xl font-bold">비밀번호 변경</Heading>
+      <Heading className="text-2xl font-bold">비밀번호 찾기</Heading>
       <FindPasswordForm inputList={inputList} onSubmit={handleFormSubmit} />
       {isError && (
         <ErrorMessage className="mt-4">{FINDPASSWORD_ERROR.FIND_PASSWORD_FAILED}</ErrorMessage>

--- a/src/pages/User/api/index.ts
+++ b/src/pages/User/api/index.ts
@@ -17,4 +17,14 @@ const resetPassword = (payload: ResetPasswordRequest): Promise<AxiosResponse> =>
   return api.patch(`${API_URL}/{username}/`, payload);
 };
 
-export { loginUser, registerUser, resetPassword };
+const findPassword = (payload: FindPasswordRequest): Promise<AxiosResponse> => {
+  // Todo: 전역 username 가져오도록 변경하기
+  return api.patch(`${API_URL}/{username}/`, payload);
+};
+
+const resignUser = (): Promise<AxiosResponse> => {
+  // Todo: 전역 username 가져오도록 변경하기
+  return api.delete(`${API_URL}/{username}/`);
+};
+
+export { loginUser, registerUser, resetPassword, findPassword, resignUser };

--- a/src/pages/User/api/index.ts
+++ b/src/pages/User/api/index.ts
@@ -19,7 +19,7 @@ const resetPassword = (payload: ResetPasswordRequest): Promise<AxiosResponse> =>
 
 const findPassword = (payload: FindPasswordRequest): Promise<AxiosResponse> => {
   // Todo: 전역 username 가져오도록 변경하기
-  return api.patch(`${API_URL}/{username}/`, payload);
+  return api.post(`${API_URL}/apply_reset_password`, payload);
 };
 
 const resignUser = (): Promise<AxiosResponse> => {

--- a/src/pages/User/components/FindPasswordForm.tsx
+++ b/src/pages/User/components/FindPasswordForm.tsx
@@ -16,11 +16,12 @@ export function FindPasswordForm({ inputList, onSubmit }: FindPasswordFormProps)
     <form onSubmit={onSubmit} className="flex flex-col gap-3">
       {Object.entries(inputList).map(([key, { type, value, error, handleInputChange }]) => (
         <>
-          <Label htmlFor="email">{INPUT[key.toUpperCase()]}</Label>
+          <Label htmlFor="email">가입한 이메일 주소를 입력해주세요.</Label>
           <Input
             type={type}
             id="EMAIL"
             value={value}
+            placeholder="이메일"
             onChange={(e) => {
               handleInputChange(e, inputList.currentEmail.value);
             }}
@@ -28,7 +29,7 @@ export function FindPasswordForm({ inputList, onSubmit }: FindPasswordFormProps)
           {error && <ErrorMessage>{FINDPASSWORD_ERROR[key.toUpperCase()]}</ErrorMessage>}
         </>
       ))}
-      <Button disabled={!isFormValid}>{PAGE['FIND_PASSWORD']}</Button>
+      <Button disabled={!isFormValid}>메일 전송</Button>
     </form>
   );
 }

--- a/src/pages/User/components/FindPasswordForm.tsx
+++ b/src/pages/User/components/FindPasswordForm.tsx
@@ -1,0 +1,34 @@
+import { Label, Input, Button, ErrorMessage } from '@/components';
+import { PAGE } from '@/constants';
+
+import { INPUT, FINDPASSWORD_ERROR } from '../constants';
+import { useFindPasswordForm } from '../hooks';
+
+type FindPasswordFormProps = {
+  inputList: ReturnType<typeof useFindPasswordForm>;
+  onSubmit: (e: React.FormEvent<HTMLFormElement> & { target: HTMLFormElement }) => void;
+};
+
+export function FindPasswordForm({ inputList, onSubmit }: FindPasswordFormProps) {
+  const isFormValid = Object.values(inputList).every(({ value, error }) => value && !error);
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      {Object.entries(inputList).map(([key, { type, value, error, handleInputChange }]) => (
+        <>
+          <Label htmlFor="email">{INPUT[key.toUpperCase()]}</Label>
+          <Input
+            type={type}
+            id="EMAIL"
+            value={value}
+            onChange={(e) => {
+              handleInputChange(e, inputList.currentEmail.value);
+            }}
+          />
+          {error && <ErrorMessage>{FINDPASSWORD_ERROR[key.toUpperCase()]}</ErrorMessage>}
+        </>
+      ))}
+      <Button disabled={!isFormValid}>{PAGE['FIND_PASSWORD']}</Button>
+    </form>
+  );
+}

--- a/src/pages/User/components/index.ts
+++ b/src/pages/User/components/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthForm';
+export * from './FindPasswordForm';

--- a/src/pages/User/constants/errorMessage.ts
+++ b/src/pages/User/constants/errorMessage.ts
@@ -18,3 +18,8 @@ export const RESETPASSWORD_ERROR: { [key: string]: string } = {
   NEWPASSWORDCHECK: '비밀번호와 일치하지 않습니다.',
   RESET_PASSWORD_FAILED: '비밀번호 변경에 실패하였습니다.',
 };
+
+export const FINDPASSWORD_ERROR: { [key: string]: string } = {
+  CURRENTEMAIL: '이메일 형식이 올바르지 않습니다.',
+  FIND_PASSWORD_FAILED: '비밀번호 찾기에 실패하였습니다.',
+};

--- a/src/pages/User/hooks/index.ts
+++ b/src/pages/User/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useInput';
 export * from './useAuthForm';
 export * from './useResetPasswordForm';
+export * from './useFindPasswordForm';

--- a/src/pages/User/hooks/query/index.ts
+++ b/src/pages/User/hooks/query/index.ts
@@ -1,3 +1,4 @@
 export * from './useLoginMutation';
 export * from './useRegisterMutation';
 export * from './useResetPasswordMutation';
+export * from './useFindPasswordMutation';

--- a/src/pages/User/hooks/query/useFindPasswordMutation.ts
+++ b/src/pages/User/hooks/query/useFindPasswordMutation.ts
@@ -1,0 +1,17 @@
+import { PATH } from '@/constants';
+import { AxiosError, AxiosResponse } from 'axios';
+import { useMutation, UseMutationOptions } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { findPassword } from '../../api';
+
+export const useFindPasswordMutation = (
+  options?: UseMutationOptions<AxiosResponse, AxiosError, FindPasswordRequest>
+) => {
+  const navigate = useNavigate();
+  return useMutation((email) => findPassword(email), {
+    ...options,
+    onSuccess: () => {
+      navigate(PATH.USER_HOME);
+    },
+  });
+};

--- a/src/pages/User/hooks/useFindPasswordForm.ts
+++ b/src/pages/User/hooks/useFindPasswordForm.ts
@@ -1,0 +1,19 @@
+import { REGEXP } from '../constants';
+import { useInput } from './useInput';
+
+const emailInput = {
+  type: 'email',
+  required: true,
+};
+
+export const useFindPasswordForm = () => {
+  const findPasswordForm = {
+    currentEmail: {
+      ...emailInput,
+      ...useInput(),
+      regexp: REGEXP['EMAIL'],
+    },
+  };
+
+  return findPasswordForm;
+};

--- a/src/pages/User/index.ts
+++ b/src/pages/User/index.ts
@@ -1,2 +1,3 @@
 export { default as Login } from './Login';
 export { default as Register } from './Register';
+export * from './FindPassword';

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -43,3 +43,7 @@ type ResetPasswordRequest = {
   new_password: string;
   new_password2: string;
 };
+
+type FindPasswordRequest = {
+  email: string;
+};


### PR DESCRIPTION
## 이슈 번호

<!-- 관련 이슈 번호를 연결 -->

## 구현 기능
* 비밀번호 찾기 구현
## 변경 로직

## 스크린샷
![image](https://user-images.githubusercontent.com/81199414/219579808-ecadf27f-eb41-4408-89a5-2165f0199020.png)

## 참고 사항
* 비밀번호 찾을 때 이메일을 백엔드에 보내줘야 하는데 관련된 API가 없는듯함.